### PR TITLE
[REFACTOR] バックエンド責務の見直しに伴う処理の共通化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ PROJECT_MEMORY.md
 .github/instructions/codacy.instructions.md
 AGENTS.md
 .envrc
+.codex

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet';
 import bookRouter from './routes/books';
 import authRouter from './routes/auth';
 import commentRouter from './routes/comments';
+import { apiErrorHandler } from './middleware/errorHandler';
 import reviewRouter from './routes/reviews';
 import usersRouter from './routes/users';
 import { logger } from './utils/logger';
@@ -62,4 +63,7 @@ app.use('/api', reviewRouter);
 
 // グローバルな認証なしでコメントルートをマウント; 必要な個々のルートで認証を強制
 app.use('/api', commentRouter);
+
+// API エラーのレスポンス整形はミドルウェアで一元化する
+app.use(apiErrorHandler);
 export default app;

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,29 +1,10 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
-import { ApiError } from '../errors/ApiError';
-import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as authService from '../services/auth.service';
-import { logger } from '../utils/logger';
+import { sendAuthenticationRequired } from '../middleware/errorHandler';
+import { asyncHandler } from '../utils/asyncHandler';
 import { validateLogin, validateRegister } from '../validators/auth.validator';
-
-/**
- * 予期しない例外時に共通の 500 レスポンスを返します。
- *
- * @param res - Express Response
- * @param logMessage - ログ出力する固定メッセージ
- * @returns 500 エラーレスポンス
- */
-function sendInternalServerError(res: Response, logMessage: string) {
-  logger.error(logMessage);
-  return res.status(500).json({
-    success: false,
-    error: {
-      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-      code: 'INTERNAL_SERVER_ERROR',
-    },
-  });
-}
 
 /**
  * ユーザー登録 API ハンドラー。
@@ -32,38 +13,22 @@ function sendInternalServerError(res: Response, logMessage: string) {
  * @param res - Express Response
  * @returns 登録結果
  */
-export async function register(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateRegister(req);
-    if (!parseResult.success) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.VALIDATION_FAILED,
-          code: 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const data = await authService.register(parseResult.data);
-    return res.status(201).json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    return sendInternalServerError(res, '[AUTH REGISTER] unexpected error occurred');
+export const register = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateRegister(req);
+  if (!parseResult.success) {
+    return res.status(400).json({
+      success: false,
+      error: {
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        code: 'VALIDATION_ERROR',
+        details: parseResult.errors,
+      },
+    });
   }
-}
+
+  const data = await authService.register(parseResult.data);
+  return res.status(201).json({ success: true, data });
+});
 
 /**
  * ログイン API ハンドラー。
@@ -72,34 +37,22 @@ export async function register(
  * @param res - Express Response
  * @returns ログイン結果
  */
-export async function login(req: Request, res: Response, next?: NextFunction): Promise<Response> {
-  try {
-    const parseResult = validateLogin(req);
-    if (!parseResult.success) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.VALIDATION_FAILED,
-          code: 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const data = await authService.login(parseResult.data);
-    return res.status(200).json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    return sendInternalServerError(res, '[AUTH LOGIN] unexpected error occurred');
+export const login = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateLogin(req);
+  if (!parseResult.success) {
+    return res.status(400).json({
+      success: false,
+      error: {
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        code: 'VALIDATION_ERROR',
+        details: parseResult.errors,
+      },
+    });
   }
-}
+
+  const data = await authService.login(parseResult.data);
+  return res.status(200).json({ success: true, data });
+});
 
 /**
  * 自分のプロフィール取得 API ハンドラー。
@@ -108,24 +61,12 @@ export async function login(req: Request, res: Response, next?: NextFunction): P
  * @param res - Express Response
  * @returns プロフィール情報
  */
-export async function me(req: Request, res: Response, next?: NextFunction): Promise<Response> {
-  try {
-    const userId = req.userId;
-    if (!userId) {
-      return sendAuthenticationRequired(res);
-    }
-
-    const data = await authService.getMyProfile(userId);
-    return res.status(200).json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    return sendInternalServerError(res, '[AUTH ME] unexpected error occurred');
+export const me = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const userId = req.userId;
+  if (!userId) {
+    return sendAuthenticationRequired(res);
   }
-}
+
+  const data = await authService.getMyProfile(userId);
+  return res.status(200).json({ success: true, data });
+});

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,21 +1,19 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
+import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as authService from '../services/auth.service';
 import { logger } from '../utils/logger';
 import { validateLogin, validateRegister } from '../validators/auth.validator';
 
-function sendApiError(res: Response, error: ApiError) {
-  return res.status(error.statusCode).json({
-    success: false,
-    error: {
-      message: error.message,
-      code: error.code,
-    },
-  });
-}
-
+/**
+ * 予期しない例外時に共通の 500 レスポンスを返します。
+ *
+ * @param res - Express Response
+ * @param logMessage - ログ出力する固定メッセージ
+ * @returns 500 エラーレスポンス
+ */
 function sendInternalServerError(res: Response, logMessage: string) {
   logger.error(logMessage);
   return res.status(500).json({
@@ -34,7 +32,11 @@ function sendInternalServerError(res: Response, logMessage: string) {
  * @param res - Express Response
  * @returns 登録結果
  */
-export async function register(req: Request, res: Response): Promise<Response> {
+export async function register(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateRegister(req);
     if (!parseResult.success) {
@@ -52,6 +54,10 @@ export async function register(req: Request, res: Response): Promise<Response> {
     return res.status(201).json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -66,7 +72,7 @@ export async function register(req: Request, res: Response): Promise<Response> {
  * @param res - Express Response
  * @returns ログイン結果
  */
-export async function login(req: Request, res: Response): Promise<Response> {
+export async function login(req: Request, res: Response, next?: NextFunction): Promise<Response> {
   try {
     const parseResult = validateLogin(req);
     if (!parseResult.success) {
@@ -84,6 +90,10 @@ export async function login(req: Request, res: Response): Promise<Response> {
     return res.status(200).json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -98,23 +108,21 @@ export async function login(req: Request, res: Response): Promise<Response> {
  * @param res - Express Response
  * @returns プロフィール情報
  */
-export async function me(req: Request, res: Response): Promise<Response> {
+export async function me(req: Request, res: Response, next?: NextFunction): Promise<Response> {
   try {
     const userId = req.userId;
     if (!userId) {
-      return res.status(401).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.AUTHENTICATION_REQUIRED,
-          code: 'AUTHENTICATION_REQUIRED',
-        },
-      });
+      return sendAuthenticationRequired(res);
     }
 
     const data = await authService.getMyProfile(userId);
     return res.status(200).json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 

--- a/server/src/controllers/book.controller.ts
+++ b/server/src/controllers/book.controller.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
+import { sendApiError } from '../middleware/errorHandler';
 import * as bookService from '../services/book.service';
 import {
   validateCreateBook,
@@ -12,32 +13,6 @@ import {
   validateUpdateBook,
 } from '../validators/book.validator';
 import { logger } from '../utils/logger';
-
-type ErrorResponse = {
-  message: string;
-  code: string;
-  details?: { field: string; message: string }[];
-};
-
-/**
- * `ApiError` を API レスポンス形式に変換して返します。
- *
- * @param res - Express Response
- * @param error - service 層などから送出されたアプリケーション例外
- * @returns エラーレスポンス
- */
-function sendApiError(res: Response, error: ApiError) {
-  const body: ErrorResponse = {
-    message: error.message,
-    code: error.code,
-  };
-
-  if (error.details) {
-    body.details = error.details;
-  }
-
-  return res.status(error.statusCode).json({ success: false, error: body });
-}
 
 /**
  * 書籍一覧を取得します。
@@ -50,7 +25,11 @@ function sendApiError(res: Response, error: ApiError) {
  * @param res - Express Response
  * @returns 書籍一覧とページング情報
  */
-export async function listBooks(req: Request, res: Response): Promise<Response> {
+export async function listBooks(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateListBooksQuery(req);
 
@@ -70,6 +49,10 @@ export async function listBooks(req: Request, res: Response): Promise<Response> 
     return res.json({ success: true, data: result });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -91,7 +74,11 @@ export async function listBooks(req: Request, res: Response): Promise<Response> 
  * @param res - Express Response
  * @returns 書籍詳細
  */
-export async function getBookDetail(req: Request, res: Response): Promise<Response> {
+export async function getBookDetail(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateGetBookDetail(req);
 
@@ -112,6 +99,10 @@ export async function getBookDetail(req: Request, res: Response): Promise<Respon
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -133,7 +124,11 @@ export async function getBookDetail(req: Request, res: Response): Promise<Respon
  * @param res - Express Response
  * @returns 作成済み書籍
  */
-export async function createBook(req: Request, res: Response): Promise<Response> {
+export async function createBook(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateCreateBook(req);
 
@@ -152,6 +147,10 @@ export async function createBook(req: Request, res: Response): Promise<Response>
     return res.status(201).json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -176,7 +175,11 @@ export async function createBook(req: Request, res: Response): Promise<Response>
  * @param res - Express Response
  * @returns 更新後の書籍
  */
-export async function updateBook(req: Request, res: Response): Promise<Response> {
+export async function updateBook(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateUpdateBook(req);
 
@@ -199,6 +202,10 @@ export async function updateBook(req: Request, res: Response): Promise<Response>
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -220,7 +227,11 @@ export async function updateBook(req: Request, res: Response): Promise<Response>
  * @param res - Express Response
  * @returns レビュー一覧とページング情報
  */
-export async function listBookReviews(req: Request, res: Response): Promise<Response> {
+export async function listBookReviews(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateGetBookReviews(req);
 
@@ -240,6 +251,10 @@ export async function listBookReviews(req: Request, res: Response): Promise<Resp
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -264,7 +279,11 @@ export async function listBookReviews(req: Request, res: Response): Promise<Resp
  * @param res - Express Response
  * @returns 204 No Content
  */
-export async function deleteBook(req: Request, res: Response): Promise<Response> {
+export async function deleteBook(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateDeleteBook(req);
 
@@ -284,6 +303,10 @@ export async function deleteBook(req: Request, res: Response): Promise<Response>
     return res.sendStatus(204);
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 

--- a/server/src/controllers/book.controller.ts
+++ b/server/src/controllers/book.controller.ts
@@ -1,9 +1,8 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
-import { ApiError } from '../errors/ApiError';
-import { sendApiError } from '../middleware/errorHandler';
 import * as bookService from '../services/book.service';
+import { asyncHandler } from '../utils/asyncHandler';
 import {
   validateCreateBook,
   validateDeleteBook,
@@ -12,7 +11,6 @@ import {
   validateListBooksQuery,
   validateUpdateBook,
 } from '../validators/book.validator';
-import { logger } from '../utils/logger';
 
 /**
  * 書籍一覧を取得します。
@@ -25,47 +23,24 @@ import { logger } from '../utils/logger';
  * @param res - Express Response
  * @returns 書籍一覧とページング情報
  */
-export async function listBooks(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateListBooksQuery(req);
+export const listBooks = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateListBooksQuery(req);
 
-    // 不正なクエリで下位層に進まないよう、controller で早期 return します。
-    if (!parseResult.success) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.VALIDATION_FAILED,
-          code: 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const result = await bookService.listBooks(parseResult.data);
-    return res.json({ success: true, data: result });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS GET LIST] unexpected error occurred', error);
-    return res.status(500).json({
+  // 不正なクエリで下位層に進まないよう、controller で早期 return します。
+  if (!parseResult.success) {
+    return res.status(400).json({
       success: false,
       error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        code: 'VALIDATION_ERROR',
+        details: parseResult.errors,
       },
     });
   }
-}
+
+  const result = await bookService.listBooks(parseResult.data);
+  return res.json({ success: true, data: result });
+});
 
 /**
  * 指定 ID の書籍詳細を取得します。
@@ -74,12 +49,8 @@ export async function listBooks(
  * @param res - Express Response
  * @returns 書籍詳細
  */
-export async function getBookDetail(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const getBookDetail = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const parseResult = validateGetBookDetail(req);
 
     if (!parseResult.success) {
@@ -97,25 +68,8 @@ export async function getBookDetail(
 
     const data = await bookService.getBookDetail(parseResult.data.bookId);
     return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS GET DETAIL] unexpected error occurred', error);
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);
 
 /**
  * 書籍を新規作成します。
@@ -124,46 +78,23 @@ export async function getBookDetail(
  * @param res - Express Response
  * @returns 作成済み書籍
  */
-export async function createBook(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateCreateBook(req);
+export const createBook = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateCreateBook(req);
 
-    if (!parseResult.success) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.VALIDATION_FAILED,
-          code: 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const data = await bookService.createBook(parseResult.data);
-    return res.status(201).json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS POST] unexpected error occurred', error);
-    return res.status(500).json({
+  if (!parseResult.success) {
+    return res.status(400).json({
       success: false,
       error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        code: 'VALIDATION_ERROR',
+        details: parseResult.errors,
       },
     });
   }
-}
+
+  const data = await bookService.createBook(parseResult.data);
+  return res.status(201).json({ success: true, data });
+});
 
 /**
  * 書籍を部分更新します。
@@ -175,50 +106,25 @@ export async function createBook(
  * @param res - Express Response
  * @returns 更新後の書籍
  */
-export async function updateBook(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateUpdateBook(req);
+export const updateBook = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateUpdateBook(req);
 
-    if (!parseResult.success) {
-      // ID 不正だけは既存 API のエラーコード互換を維持します。
-      const hasInvalidBookId = parseResult.errors.some((error) => error.code === 'INVALID_BOOK_ID');
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: hasInvalidBookId
-            ? ERROR_MESSAGES.INVALID_BOOK_ID
-            : ERROR_MESSAGES.VALIDATION_FAILED,
-          code: hasInvalidBookId ? 'INVALID_BOOK_ID' : 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const data = await bookService.updateBook(parseResult.data.bookId, parseResult.data.data);
-    return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS PUT] unexpected error occurred', error);
-    return res.status(500).json({
+  if (!parseResult.success) {
+    // ID 不正だけは既存 API のエラーコード互換を維持します。
+    const hasInvalidBookId = parseResult.errors.some((error) => error.code === 'INVALID_BOOK_ID');
+    return res.status(400).json({
       success: false,
       error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
+        message: hasInvalidBookId ? ERROR_MESSAGES.INVALID_BOOK_ID : ERROR_MESSAGES.VALIDATION_FAILED,
+        code: hasInvalidBookId ? 'INVALID_BOOK_ID' : 'VALIDATION_ERROR',
+        details: parseResult.errors,
       },
     });
   }
-}
+
+  const data = await bookService.updateBook(parseResult.data.bookId, parseResult.data.data);
+  return res.json({ success: true, data });
+});
 
 /**
  * 指定書籍に紐づくレビュー一覧を取得します。
@@ -227,12 +133,8 @@ export async function updateBook(
  * @param res - Express Response
  * @returns レビュー一覧とページング情報
  */
-export async function listBookReviews(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const listBookReviews = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const parseResult = validateGetBookReviews(req);
 
     if (!parseResult.success) {
@@ -249,25 +151,8 @@ export async function listBookReviews(
 
     const data = await bookService.listBookReviews(parseResult.data);
     return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS REVIEWS GET] unexpected error occurred', error);
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);
 
 /**
  * 書籍を削除します。
@@ -279,44 +164,21 @@ export async function listBookReviews(
  * @param res - Express Response
  * @returns 204 No Content
  */
-export async function deleteBook(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateDeleteBook(req);
+export const deleteBook = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateDeleteBook(req);
 
-    if (!parseResult.success) {
-      const firstErrorCode = parseResult.errors[0]?.code || 'VALIDATION_ERROR';
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.INVALID_BOOK_ID,
-          code: firstErrorCode,
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    await bookService.deleteBook(parseResult.data.bookId);
-    return res.sendStatus(204);
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[BOOKS DELETE] unexpected error occurred', error);
-    return res.status(500).json({
+  if (!parseResult.success) {
+    const firstErrorCode = parseResult.errors[0]?.code || 'VALIDATION_ERROR';
+    return res.status(400).json({
       success: false,
       error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
+        message: ERROR_MESSAGES.INVALID_BOOK_ID,
+        code: firstErrorCode,
+        details: parseResult.errors,
       },
     });
   }
-}
+
+  await bookService.deleteBook(parseResult.data.bookId);
+  return res.sendStatus(204);
+});

--- a/server/src/controllers/comment.controller.ts
+++ b/server/src/controllers/comment.controller.ts
@@ -1,32 +1,14 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
+import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as commentService from '../services/comment.service';
 import { logger } from '../utils/logger';
 import {
   validateCreateComment,
   validateGetCommentsForReview,
 } from '../validators/comment.validator';
-
-type ErrorResponse = {
-  message: string;
-  code: string;
-  details?: { field: string; message: string }[];
-};
-
-function sendApiError(res: Response, error: ApiError) {
-  const err: ErrorResponse = {
-    message: error.message,
-    code: error.code,
-  };
-
-  if (error.details) {
-    err.details = error.details;
-  }
-
-  return res.status(error.statusCode).json({ success: false, error: err });
-}
 
 /**
  * コメント一覧取得 API ハンドラー。
@@ -35,7 +17,11 @@ function sendApiError(res: Response, error: ApiError) {
  * @param res - Express Response
  * @returns コメント一覧
  */
-export async function listComments(req: Request, res: Response): Promise<Response> {
+export async function listComments(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateGetCommentsForReview(req);
     if (!parseResult.success) {
@@ -55,6 +41,10 @@ export async function listComments(req: Request, res: Response): Promise<Respons
     return res.json({ success: true, data: { comments } });
   } catch (error: unknown) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -73,17 +63,15 @@ export async function listComments(req: Request, res: Response): Promise<Respons
  * @param res - Express Response
  * @returns 作成後コメント
  */
-export async function createComment(req: Request, res: Response): Promise<Response> {
+export async function createComment(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const userId = req.userId;
     if (!userId) {
-      return res.status(401).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.AUTHENTICATION_REQUIRED,
-          code: 'AUTHENTICATION_REQUIRED',
-        },
-      });
+      return sendAuthenticationRequired(res);
     }
 
     const parseResult = validateCreateComment(req);
@@ -102,6 +90,10 @@ export async function createComment(req: Request, res: Response): Promise<Respon
     return res.status(201).json({ success: true, data: created });
   } catch (error: unknown) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 

--- a/server/src/controllers/comment.controller.ts
+++ b/server/src/controllers/comment.controller.ts
@@ -1,10 +1,9 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
-import { ApiError } from '../errors/ApiError';
-import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
+import { sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as commentService from '../services/comment.service';
-import { logger } from '../utils/logger';
+import { asyncHandler } from '../utils/asyncHandler';
 import {
   validateCreateComment,
   validateGetCommentsForReview,
@@ -17,12 +16,8 @@ import {
  * @param res - Express Response
  * @returns コメント一覧
  */
-export async function listComments(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const listComments = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const parseResult = validateGetCommentsForReview(req);
     if (!parseResult.success) {
       const firstErrorCode = parseResult.errors?.[0]?.code || 'VALIDATION_ERROR';
@@ -39,22 +34,8 @@ export async function listComments(
     const comments = await commentService.listComments(parseResult.data.reviewId);
 
     return res.json({ success: true, data: { comments } });
-  } catch (error: unknown) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[COMMENTS GET] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
-    });
   }
-}
+);
 
 /**
  * コメント作成 API ハンドラー。
@@ -63,12 +44,8 @@ export async function listComments(
  * @param res - Express Response
  * @returns 作成後コメント
  */
-export async function createComment(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const createComment = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const userId = req.userId;
     if (!userId) {
       return sendAuthenticationRequired(res);
@@ -88,19 +65,5 @@ export async function createComment(
 
     const created = await commentService.createComment({ ...parseResult.data, userId });
     return res.status(201).json({ success: true, data: created });
-  } catch (error: unknown) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[COMMENTS POST] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
-    });
   }
-}
+);

--- a/server/src/controllers/review.controller.ts
+++ b/server/src/controllers/review.controller.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
+import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as reviewService from '../services/review.service';
 import { logger } from '../utils/logger';
 import {
@@ -12,23 +13,6 @@ import {
   validateUpdateReview,
 } from '../validators/review.validator';
 
-function sendApiError(res: Response, error: ApiError) {
-  return res.status(error.statusCode).json({
-    success: false,
-    error: { message: error.message, code: error.code },
-  });
-}
-
-function sendAuthenticationRequired(res: Response) {
-  return res.status(401).json({
-    success: false,
-    error: {
-      message: ERROR_MESSAGES.AUTHENTICATION_REQUIRED,
-      code: 'AUTHENTICATION_REQUIRED',
-    },
-  });
-}
-
 /**
  * レビュー一覧取得 API ハンドラー。
  *
@@ -36,7 +20,11 @@ function sendAuthenticationRequired(res: Response) {
  * @param res - Express Response
  * @returns レビュー一覧
  */
-export async function listReviews(req: Request, res: Response): Promise<Response> {
+export async function listReviews(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateListReviewsQuery(req);
 
@@ -59,6 +47,10 @@ export async function listReviews(req: Request, res: Response): Promise<Response
     });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -77,7 +69,11 @@ export async function listReviews(req: Request, res: Response): Promise<Response
  * @param res - Express Response
  * @returns レビュー詳細
  */
-export async function getReviewDetail(req: Request, res: Response): Promise<Response> {
+export async function getReviewDetail(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateGetReviewDetail(req);
 
@@ -98,6 +94,10 @@ export async function getReviewDetail(req: Request, res: Response): Promise<Resp
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -116,7 +116,11 @@ export async function getReviewDetail(req: Request, res: Response): Promise<Resp
  * @param res - Express Response
  * @returns 204 No Content
  */
-export async function deleteReview(req: Request, res: Response): Promise<Response> {
+export async function deleteReview(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const userId = req.userId;
     if (!userId) {
@@ -146,6 +150,10 @@ export async function deleteReview(req: Request, res: Response): Promise<Respons
     return res.sendStatus(204);
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -167,7 +175,11 @@ export async function deleteReview(req: Request, res: Response): Promise<Respons
  * @param res - Express Response
  * @returns 更新後レビュー
  */
-export async function updateReview(req: Request, res: Response): Promise<Response> {
+export async function updateReview(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const userId = req.userId;
     if (!userId) {
@@ -198,6 +210,10 @@ export async function updateReview(req: Request, res: Response): Promise<Respons
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 
@@ -219,7 +235,11 @@ export async function updateReview(req: Request, res: Response): Promise<Respons
  * @param res - Express Response
  * @returns 作成後レビュー
  */
-export async function createReview(req: Request, res: Response): Promise<Response> {
+export async function createReview(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const userId = req.userId;
     if (!userId) {
@@ -247,6 +267,10 @@ export async function createReview(req: Request, res: Response): Promise<Respons
     return res.status(201).json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 

--- a/server/src/controllers/review.controller.ts
+++ b/server/src/controllers/review.controller.ts
@@ -1,10 +1,9 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
-import { ApiError } from '../errors/ApiError';
-import { sendApiError, sendAuthenticationRequired } from '../middleware/errorHandler';
+import { sendAuthenticationRequired } from '../middleware/errorHandler';
 import * as reviewService from '../services/review.service';
-import { logger } from '../utils/logger';
+import { asyncHandler } from '../utils/asyncHandler';
 import {
   validateCreateReview,
   validateDeleteReview,
@@ -20,47 +19,27 @@ import {
  * @param res - Express Response
  * @returns レビュー一覧
  */
-export async function listReviews(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
-    const parseResult = validateListReviewsQuery(req);
+export const listReviews = asyncHandler(async (req: Request, res: Response): Promise<Response> => {
+  const parseResult = validateListReviewsQuery(req);
 
-    if (!parseResult.success) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.VALIDATION_FAILED,
-          code: 'VALIDATION_ERROR',
-          details: parseResult.errors,
-        },
-      });
-    }
-
-    const result = await reviewService.listReviews(parseResult.data);
-
-    return res.json({
-      success: true,
-      data: result,
-    });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[REVIEWS GET] unexpected error occurred');
-    return res.status(500).json({
+  if (!parseResult.success) {
+    return res.status(400).json({
       success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
+      error: {
+        message: ERROR_MESSAGES.VALIDATION_FAILED,
+        code: 'VALIDATION_ERROR',
+        details: parseResult.errors,
+      },
     });
   }
-}
+
+  const result = await reviewService.listReviews(parseResult.data);
+
+  return res.json({
+    success: true,
+    data: result,
+  });
+});
 
 /**
  * レビュー詳細取得 API ハンドラー。
@@ -69,12 +48,8 @@ export async function listReviews(
  * @param res - Express Response
  * @returns レビュー詳細
  */
-export async function getReviewDetail(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const getReviewDetail = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const parseResult = validateGetReviewDetail(req);
 
     if (!parseResult.success) {
@@ -92,22 +67,8 @@ export async function getReviewDetail(
     const data = await reviewService.getReviewDetail(parseResult.data.reviewId);
 
     return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[REVIEWS GET DETAIL] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
-    });
   }
-}
+);
 
 /**
  * レビュー削除 API ハンドラー。
@@ -116,12 +77,8 @@ export async function getReviewDetail(
  * @param res - Express Response
  * @returns 204 No Content
  */
-export async function deleteReview(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const deleteReview = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const userId = req.userId;
     if (!userId) {
       return sendAuthenticationRequired(res);
@@ -148,25 +105,8 @@ export async function deleteReview(
     });
 
     return res.sendStatus(204);
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[REVIEWS DELETE] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);
 
 /**
  * レビュー更新 API ハンドラー。
@@ -175,12 +115,8 @@ export async function deleteReview(
  * @param res - Express Response
  * @returns 更新後レビュー
  */
-export async function updateReview(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const updateReview = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const userId = req.userId;
     if (!userId) {
       return sendAuthenticationRequired(res);
@@ -208,25 +144,8 @@ export async function updateReview(
     });
 
     return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[REVIEWS PUT] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);
 
 /**
  * レビュー作成 API ハンドラー。
@@ -235,12 +154,8 @@ export async function updateReview(
  * @param res - Express Response
  * @returns 作成後レビュー
  */
-export async function createReview(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const createReview = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const userId = req.userId;
     if (!userId) {
       return sendAuthenticationRequired(res);
@@ -265,22 +180,5 @@ export async function createReview(
     });
 
     return res.status(201).json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[REVIEWS POST] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,10 +1,8 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
-import { ApiError } from '../errors/ApiError';
-import { sendApiError } from '../middleware/errorHandler';
 import * as userService from '../services/user.service';
-import { logger } from '../utils/logger';
+import { asyncHandler } from '../utils/asyncHandler';
 import { validateGetUserProfile } from '../validators/user.validator';
 
 /**
@@ -14,12 +12,8 @@ import { validateGetUserProfile } from '../validators/user.validator';
  * @param res - Express Response
  * @returns ユーザー情報
  */
-export async function getUserProfile(
-  req: Request,
-  res: Response,
-  next?: NextFunction
-): Promise<Response> {
-  try {
+export const getUserProfile = asyncHandler(
+  async (req: Request, res: Response): Promise<Response> => {
     const parseResult = validateGetUserProfile(req);
     if (!parseResult.success) {
       return res.status(400).json({
@@ -34,22 +28,5 @@ export async function getUserProfile(
 
     const data = await userService.getUserProfile(parseResult.data.userId);
     return res.json({ success: true, data });
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (next) {
-        next(error);
-        return res;
-      }
-      return sendApiError(res, error);
-    }
-
-    logger.error('[USERS GET PROFILE] unexpected error occurred');
-    return res.status(500).json({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
   }
-}
+);

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -1,21 +1,11 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
+import { sendApiError } from '../middleware/errorHandler';
 import * as userService from '../services/user.service';
 import { logger } from '../utils/logger';
 import { validateGetUserProfile } from '../validators/user.validator';
-
-function sendApiError(res: Response, error: ApiError) {
-  return res.status(error.statusCode).json({
-    success: false,
-    error: {
-      message: error.message,
-      code: error.code,
-      ...(error.details && { details: error.details }),
-    },
-  });
-}
 
 /**
  * ユーザープロフィール取得 API ハンドラー。
@@ -24,7 +14,11 @@ function sendApiError(res: Response, error: ApiError) {
  * @param res - Express Response
  * @returns ユーザー情報
  */
-export async function getUserProfile(req: Request, res: Response): Promise<Response> {
+export async function getUserProfile(
+  req: Request,
+  res: Response,
+  next?: NextFunction
+): Promise<Response> {
   try {
     const parseResult = validateGetUserProfile(req);
     if (!parseResult.success) {
@@ -42,6 +36,10 @@ export async function getUserProfile(req: Request, res: Response): Promise<Respo
     return res.json({ success: true, data });
   } catch (error) {
     if (error instanceof ApiError) {
+      if (next) {
+        next(error);
+        return res;
+      }
       return sendApiError(res, error);
     }
 

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -17,7 +17,7 @@ export type ErrorResponse = {
  * @param error - service / repository 層から送出されたアプリケーション例外
  * @returns 整形済みエラーレスポンス
  */
-export function sendApiError(res: Response, error: ApiError) {
+export function sendApiError(res: Response, error: ApiError): Response {
   const body: ErrorResponse = {
     message: error.message,
     code: error.code,
@@ -36,7 +36,7 @@ export function sendApiError(res: Response, error: ApiError) {
  * @param res - Express の Response
  * @returns 認証必須エラーレスポンス
  */
-export function sendAuthenticationRequired(res: Response) {
+export function sendAuthenticationRequired(res: Response): Response {
   return res.status(401).json({
     success: false,
     error: {
@@ -53,19 +53,27 @@ export function sendAuthenticationRequired(res: Response) {
  * controller では `next(error)` で本ハンドラに委譲することを想定します。
  */
 export const apiErrorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  void _next;
+
   if (error instanceof ApiError) {
     sendApiError(res, error);
     return;
   }
 
-  const status = (error as any).status || (error as any).statusCode;
-  const errorType = (error as any).type;
+  const typedError = error as {
+    status?: number;
+    statusCode?: number;
+    type?: string;
+    message?: string;
+  };
+  const status = typedError.status ?? typedError.statusCode;
+  const errorType = typedError.type;
 
   if (status === 413 || errorType === 'entity.too.large') {
     res.status(413).json({
       success: false,
       error: {
-        message: (error as Error).message || 'Payload too large',
+        message: typedError.message || 'Payload too large',
         code: 'PAYLOAD_TOO_LARGE',
       },
     });

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,69 @@
+import { ErrorRequestHandler, Response } from 'express';
+
+import { ERROR_MESSAGES } from '../constants/error-messages';
+import { ApiError } from '../errors/ApiError';
+import { logger } from '../utils/logger';
+
+export type ErrorResponse = {
+  message: string;
+  code: string;
+  details?: { field: string; message: string }[];
+};
+
+/**
+ * `ApiError` を標準の API エラーレスポンスへ変換して返します。
+ *
+ * @param res - Express の Response
+ * @param error - service / repository 層から送出されたアプリケーション例外
+ * @returns 整形済みエラーレスポンス
+ */
+export function sendApiError(res: Response, error: ApiError) {
+  const body: ErrorResponse = {
+    message: error.message,
+    code: error.code,
+  };
+
+  if (error.details) {
+    body.details = error.details;
+  }
+
+  return res.status(error.statusCode).json({ success: false, error: body });
+}
+
+/**
+ * 未認証リクエストに対する 401 レスポンスを返します。
+ *
+ * @param res - Express の Response
+ * @returns 認証必須エラーレスポンス
+ */
+export function sendAuthenticationRequired(res: Response) {
+  return res.status(401).json({
+    success: false,
+    error: {
+      message: ERROR_MESSAGES.AUTHENTICATION_REQUIRED,
+      code: 'AUTHENTICATION_REQUIRED',
+    },
+  });
+}
+
+/**
+ * API 全体の共通エラーハンドラ。
+ *
+ * `ApiError` は定義済みフォーマットで返却し、それ以外は 500 として扱います。
+ * controller では `next(error)` で本ハンドラに委譲することを想定します。
+ */
+export const apiErrorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  if (error instanceof ApiError) {
+    sendApiError(res, error);
+    return;
+  }
+
+  logger.error('[ERROR-HANDLER] unexpected error occurred', error);
+  res.status(500).json({
+    success: false,
+    error: {
+      message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+      code: 'INTERNAL_SERVER_ERROR',
+    },
+  });
+};

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -58,6 +58,20 @@ export const apiErrorHandler: ErrorRequestHandler = (error, _req, res, _next) =>
     return;
   }
 
+  const status = (error as any).status || (error as any).statusCode;
+  const errorType = (error as any).type;
+
+  if (status === 413 || errorType === 'entity.too.large') {
+    res.status(413).json({
+      success: false,
+      error: {
+        message: (error as Error).message || 'Payload too large',
+        code: 'PAYLOAD_TOO_LARGE',
+      },
+    });
+    return;
+  }
+
   logger.error('[ERROR-HANDLER] unexpected error occurred', error);
   res.status(500).json({
     success: false,

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -69,6 +69,17 @@ export const apiErrorHandler: ErrorRequestHandler = (error, _req, res, _next) =>
   const status = typedError.status ?? typedError.statusCode;
   const errorType = typedError.type;
 
+  if (status === 400 || errorType === 'entity.parse.failed') {
+    res.status(400).json({
+      success: false,
+      error: {
+        message: typedError.message || 'Invalid JSON',
+        code: 'INVALID_JSON',
+      },
+    });
+    return;
+  }
+
   if (status === 413 || errorType === 'entity.too.large') {
     res.status(413).json({
       success: false,

--- a/server/src/repositories/comment.repository.ts
+++ b/server/src/repositories/comment.repository.ts
@@ -1,8 +1,6 @@
 import Comment from '../models/Comment';
-import Review from '../models/Review';
 
 export type CommentInstance = InstanceType<typeof Comment>;
-export type ReviewInstance = InstanceType<typeof Review>;
 
 export type CreateCommentRepositoryInput = {
   content: string;
@@ -19,16 +17,6 @@ export type CreateCommentRepositoryInput = {
  */
 export async function findCommentsByReviewId(reviewId: number): Promise<CommentInstance[]> {
   return Comment.findAll({ where: { reviewId }, order: [['createdAt', 'DESC']] });
-}
-
-/**
- * 主キーでレビューを取得する。
- *
- * @param reviewId - レビュー ID
- * @returns レビュー、未存在時は null
- */
-export async function findReviewById(reviewId: number): Promise<ReviewInstance | null> {
-  return Review.findByPk(reviewId);
 }
 
 /**

--- a/server/src/repositories/review.repository.ts
+++ b/server/src/repositories/review.repository.ts
@@ -1,4 +1,4 @@
-import { Op, Transaction } from 'sequelize';
+import { Transaction } from 'sequelize';
 
 import Book from '../models/Book';
 import Comment from '../models/Comment';

--- a/server/src/repositories/review.repository.ts
+++ b/server/src/repositories/review.repository.ts
@@ -33,11 +33,11 @@ function createReviewsWhereClause(
   const where: Record<string | symbol, unknown> = {};
 
   if (queryDto.bookId !== undefined) {
-    where.bookId = { [Op.eq]: queryDto.bookId };
+    where.bookId = queryDto.bookId;
   }
 
   if (queryDto.userId !== undefined) {
-    where.userId = { [Op.eq]: queryDto.userId };
+    where.userId = queryDto.userId;
   }
 
   return where;

--- a/server/src/repositories/review.repository.ts
+++ b/server/src/repositories/review.repository.ts
@@ -1,20 +1,13 @@
-import { Transaction } from 'sequelize';
+import { Op, Transaction } from 'sequelize';
 
 import Book from '../models/Book';
 import Comment from '../models/Comment';
 import Review from '../models/Review';
 import User from '../models/Users';
-import { sequelize } from '../sequelize';
+import { ListReviewsQueryDto } from '../modules/review/dto/review.dto';
 
 export type ReviewInstance = InstanceType<typeof Review>;
-export type BookInstance = InstanceType<typeof Book>;
 export type CommentInstance = InstanceType<typeof Comment>;
-
-export type FindReviewsWithPaginationInput = {
-  where: Record<string, unknown>;
-  limit: number;
-  offset: number;
-};
 
 export type CreateReviewRepositoryInput = {
   bookId: number;
@@ -34,15 +27,34 @@ export type FindReviewsWithPaginationResult = {
   count: number;
 };
 
+function createReviewsWhereClause(
+  queryDto: Pick<ListReviewsQueryDto, 'bookId' | 'userId'>
+): Record<string | symbol, unknown> {
+  const where: Record<string | symbol, unknown> = {};
+
+  if (queryDto.bookId !== undefined) {
+    where.bookId = { [Op.eq]: queryDto.bookId };
+  }
+
+  if (queryDto.userId !== undefined) {
+    where.userId = { [Op.eq]: queryDto.userId };
+  }
+
+  return where;
+}
+
 export async function findReviewsWithPagination(
-  input: FindReviewsWithPaginationInput
+  queryDto: ListReviewsQueryDto
 ): Promise<FindReviewsWithPaginationResult> {
+  const offset = (queryDto.page - 1) * queryDto.limit;
+  const where = createReviewsWhereClause(queryDto);
+
   const result = await Review.findAndCountAll({
-    where: input.where,
+    where,
     attributes: ['id', 'bookId', 'userId', 'content', 'rating', 'createdAt', 'updatedAt'],
     order: [['createdAt', 'DESC']],
-    limit: input.limit,
-    offset: input.offset,
+    limit: queryDto.limit,
+    offset,
   });
 
   // `group` を指定していないため、`count` は数値（number）として返されます。
@@ -75,16 +87,6 @@ export async function findReviewDetailById(reviewId: number): Promise<ReviewInst
  */
 export async function findReviewById(reviewId: number): Promise<ReviewInstance | null> {
   return Review.findByPk(reviewId);
-}
-
-/**
- * 主キーで本を取得する。
- *
- * @param bookId - 本 ID
- * @returns 本、未存在時は null
- */
-export async function findBookById(bookId: number): Promise<BookInstance | null> {
-  return Book.findByPk(bookId);
 }
 
 /**
@@ -140,13 +142,4 @@ export async function deleteReview(
   transaction: Transaction
 ): Promise<void> {
   await review.destroy({ transaction });
-}
-
-/**
- * レビュー削除で使うトランザクションを作成する。
- *
- * @returns Sequelize transaction
- */
-export async function createTransaction(): Promise<Transaction> {
-  return sequelize.transaction();
 }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,10 +1,10 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { UniqueConstraintError, ValidationErrorItem } from 'sequelize';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
 import * as userRepository from '../repositories/user.repository';
+import { isUniqueConstraintError } from '../utils/sequelizeErrors';
 import type { LoginPayload, RegisterPayload } from '../validators/auth.validator';
 
 export type AuthUserDto = {
@@ -24,51 +24,6 @@ function getJwtSecret(): string {
     throw new Error('JWT_SECRET is required');
   }
   return secretKey;
-}
-
-function hasUniqueConstraintPath(error: unknown, targetPath: 'username' | 'email'): boolean {
-  if (error instanceof UniqueConstraintError) {
-    return error.errors.some((item: ValidationErrorItem) => item.path === targetPath);
-  }
-
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  const candidate = error as {
-    name?: string;
-    errors?: Array<{ path?: string }>;
-    fields?: Record<string, unknown>;
-    message?: string;
-    sqlMessage?: string;
-    original?: { sqlMessage?: string };
-    parent?: { sqlMessage?: string };
-  };
-
-  if (candidate.name !== 'SequelizeUniqueConstraintError') {
-    return false;
-  }
-
-  const hasErrorPath = (candidate.errors || []).some((item) => item.path === targetPath);
-  if (hasErrorPath) {
-    return true;
-  }
-
-  if (candidate.fields && targetPath in candidate.fields) {
-    return true;
-  }
-
-  const raw = [
-    candidate.message,
-    candidate.sqlMessage,
-    candidate.original?.sqlMessage,
-    candidate.parent?.sqlMessage,
-  ]
-    .filter((value): value is string => typeof value === 'string')
-    .join(' ')
-    .toLowerCase();
-
-  return raw.includes(targetPath);
 }
 
 function toAuthUserDto(model: userRepository.UserInstance): AuthUserDto {
@@ -111,11 +66,11 @@ export async function register(payload: RegisterPayload): Promise<AuthSuccessDto
       password: hashedPassword,
     });
   } catch (error) {
-    if (hasUniqueConstraintPath(error, 'username')) {
+    if (isUniqueConstraintError(error, ['username'])) {
       throw new ApiError(409, 'DUPLICATE_RESOURCE', ERROR_MESSAGES.DUPLICATE_USERNAME);
     }
 
-    if (hasUniqueConstraintPath(error, 'email')) {
+    if (isUniqueConstraintError(error, ['email'])) {
       throw new ApiError(409, 'DUPLICATE_RESOURCE', ERROR_MESSAGES.DUPLICATE_EMAIL);
     }
 

--- a/server/src/services/book.service.ts
+++ b/server/src/services/book.service.ts
@@ -1,4 +1,4 @@
-import { ForeignKeyConstraintError, UniqueConstraintError, ValidationErrorItem } from 'sequelize';
+import { ForeignKeyConstraintError } from 'sequelize';
 
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import { ApiError } from '../errors/ApiError';
@@ -8,59 +8,14 @@ import { sequelize } from '../sequelize';
 import * as reviewService from './review.service';
 import { CreateBookDto, ListBooksQueryDto, UpdateBookDto } from '../modules/book/dto/book.dto';
 import { logger } from '../utils/logger';
+import { normalizeListBook } from '../utils/mapper';
+import { isUniqueConstraintError } from '../utils/sequelizeErrors';
 
 type ListBookReviewsInput = {
   bookId: number;
   page: number;
   limit: number;
 };
-
-type BookListRow = {
-  toJSON?: () => Record<string, unknown>;
-  get?: (key: string) => unknown;
-};
-
-/**
- * 集計列に混在しうる値を有限数へ寄せます。
- *
- * @param value - DB / Sequelize から返る生値
- * @returns 有限数なら number、そうでなければ null
- */
-function toFiniteNumber(value: unknown): number | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) ? numericValue : null;
-}
-
-/**
- * 書籍一覧クエリの 1 行を API レスポンス形式へ正規化します。
- *
- * Sequelize の一覧結果は、モデルインスタンス経由で集計列を持つ場合と
- * plain object に近い shape で扱う場合があるため、ここで吸収します。
- * 集計列は API 契約に合わせて `averageRating` は `number | null`、
- * `reviewCount` は未評価時でも `0` へ揃えます。
- *
- * @param row - repository から返された書籍一覧の 1 行
- * @returns API レスポンスへ載せる正規化済み書籍データ
- */
-function normalizeListBook(row: BookListRow) {
-  const raw = typeof row.toJSON === 'function' ? row.toJSON() : (row as Record<string, unknown>);
-  const averageRatingValue =
-    raw.averageRating ?? (typeof row.get === 'function' ? row.get('averageRating') : undefined);
-  const reviewCountValue =
-    raw.reviewCount ?? (typeof row.get === 'function' ? row.get('reviewCount') : undefined);
-  const averageRating = toFiniteNumber(averageRatingValue);
-  const reviewCount = toFiniteNumber(reviewCountValue);
-
-  return {
-    ...raw,
-    averageRating,
-    reviewCount: reviewCount ?? 0,
-  };
-}
 
 /**
  * Sequelize の一意制約違反が「ISBN 重複」または「title + author 重複」に該当するか判定します。
@@ -72,32 +27,10 @@ function normalizeListBook(row: BookListRow) {
  * @returns 重複エラーとして扱うべき場合は true
  */
 function isIsbnUniqueConstraintError(error: unknown): boolean {
-  const hasDuplicateFields = (paths: string[]) => {
-    const hasIsbn = paths.includes('ISBN');
-    const hasTitleAuthor = paths.includes('title') && paths.includes('author');
-    return hasIsbn || hasTitleAuthor;
-  };
-
-  if (error instanceof UniqueConstraintError) {
-    const paths = error.errors.map((item: ValidationErrorItem) => item.path || '').filter(Boolean);
-    return hasDuplicateFields(paths);
-  }
-
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  const candidate = error as {
-    name?: string;
-    errors?: Array<{ path?: string }>;
-  };
-
-  if (candidate.name !== 'SequelizeUniqueConstraintError') {
-    return false;
-  }
-
-  const paths = (candidate.errors || []).map((item) => item.path || '').filter(Boolean);
-  return hasDuplicateFields(paths);
+  const hasIsbn = isUniqueConstraintError(error, ['ISBN']);
+  const hasTitle = isUniqueConstraintError(error, ['title']);
+  const hasAuthor = isUniqueConstraintError(error, ['author']);
+  return hasIsbn || (hasTitle && hasAuthor);
 }
 
 /**

--- a/server/src/services/comment.service.ts
+++ b/server/src/services/comment.service.ts
@@ -4,6 +4,7 @@ import type { CommentDto, CreateCommentServiceDto } from '../modules/comment/dto
 import { ApiError } from '../errors/ApiError';
 import { ERROR_MESSAGES } from '../constants/error-messages';
 import * as commentRepository from '../repositories/comment.repository';
+import * as reviewRepository from '../repositories/review.repository';
 
 /**
  * reviewId に紐づくコメントを取得し、返信をネストした形で返す。
@@ -35,7 +36,7 @@ export async function listComments(reviewId: number): Promise<CommentDto[]> {
 export async function createComment(serviceDto: CreateCommentServiceDto): Promise<CommentDto> {
   const { reviewId, content, parentId = null, userId } = serviceDto;
 
-  const foundReview = await commentRepository.findReviewById(reviewId);
+  const foundReview = await reviewRepository.findReviewById(reviewId);
   if (!foundReview) {
     throw new ApiError(404, 'REVIEW_NOT_FOUND', ERROR_MESSAGES.REVIEW_NOT_FOUND);
   }

--- a/server/src/services/review.service.ts
+++ b/server/src/services/review.service.ts
@@ -164,7 +164,8 @@ export async function deleteReview(serviceDto: DeleteReviewServiceDto): Promise<
     throw new ApiError(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN_REVIEW_DELETE);
   }
 
-  await sequelize.transaction(async (transaction) => {
+  const transaction = await sequelize.transaction();
+  try {
     const hasComments = await reviewRepository.findAnyCommentByReviewId(reviewId, transaction);
 
     if (hasComments) {
@@ -172,7 +173,11 @@ export async function deleteReview(serviceDto: DeleteReviewServiceDto): Promise<
     }
 
     await reviewRepository.deleteReview(review, transaction);
-  });
+    await transaction.commit();
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
 
   logger.info('[REVIEWS SERVICE] review deleted', { reviewId, userId });
 }

--- a/server/src/services/review.service.ts
+++ b/server/src/services/review.service.ts
@@ -12,30 +12,7 @@ import { ERROR_MESSAGES } from '../constants/error-messages';
 import * as bookRepository from '../repositories/book.repository';
 import * as reviewRepository from '../repositories/review.repository';
 import { sequelize } from '../sequelize';
-
-/**
- * モデルインスタンスを ReviewDto に変換するヘルパー。
- *
- * @param model - Review モデルまたは toJSON を持つオブジェクト
- * @returns ReviewDto
- */
-function reviewModelToDto(model: unknown): ReviewDto {
-  const json = (
-    typeof (model as { toJSON?: unknown }).toJSON === 'function'
-      ? (model as { toJSON: () => Record<string, unknown> }).toJSON()
-      : model
-  ) as Record<string, unknown>;
-
-  return {
-    id: Number(json.id),
-    bookId: Number(json.bookId),
-    userId: json.userId === null || json.userId === undefined ? null : Number(json.userId),
-    content: String(json.content),
-    rating: json.rating === undefined ? undefined : Number(json.rating),
-    createdAt: String(json.createdAt),
-    updatedAt: String(json.updatedAt),
-  };
-}
+import { reviewModelToDto } from '../utils/mapper';
 
 /**
  * レビューのページング取得。bookId/userId による絞り込み可。

--- a/server/src/services/review.service.ts
+++ b/server/src/services/review.service.ts
@@ -9,7 +9,9 @@ import {
 import { logger } from '../utils/logger';
 import { ApiError } from '../errors/ApiError';
 import { ERROR_MESSAGES } from '../constants/error-messages';
+import * as bookRepository from '../repositories/book.repository';
 import * as reviewRepository from '../repositories/review.repository';
+import { sequelize } from '../sequelize';
 
 /**
  * モデルインスタンスを ReviewDto に変換するヘルパー。
@@ -50,20 +52,11 @@ export async function listReviews(queryDto: ListReviewsQueryDto): Promise<{
     itemsPerPage: number;
   };
 }> {
-  const { page, limit, bookId, userId } = queryDto;
-  const offset = (page - 1) * limit;
+  const { page, limit } = queryDto;
 
-  const where: Record<string, unknown> = {};
-  if (bookId !== undefined) where.bookId = bookId;
-  if (userId !== undefined) where.userId = userId;
+  logger.info('[REVIEWS SERVICE] executing DB query', queryDto);
 
-  logger.info('[REVIEWS SERVICE] executing DB query', { where, page, limit, offset });
-
-  const { rows, count } = await reviewRepository.findReviewsWithPagination({
-    where,
-    limit,
-    offset,
-  });
+  const { rows, count } = await reviewRepository.findReviewsWithPagination(queryDto);
 
   logger.info('[REVIEWS SERVICE] db returned rows=', rows.length, 'count=', count);
 
@@ -125,7 +118,7 @@ export async function getReviewDetail(reviewId: number): Promise<ReviewDetailDto
 export async function createReview(serviceDto: CreateReviewServiceDto): Promise<ReviewDto> {
   const { bookId, content, rating, userId } = serviceDto;
 
-  const book = await reviewRepository.findBookById(bookId);
+  const book = await bookRepository.findBookById(bookId);
   if (!book) {
     throw new ApiError(404, 'BOOK_NOT_FOUND', ERROR_MESSAGES.BOOK_NOT_FOUND);
   }
@@ -194,8 +187,7 @@ export async function deleteReview(serviceDto: DeleteReviewServiceDto): Promise<
     throw new ApiError(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN_REVIEW_DELETE);
   }
 
-  const transaction = await reviewRepository.createTransaction();
-  try {
+  await sequelize.transaction(async (transaction) => {
     const hasComments = await reviewRepository.findAnyCommentByReviewId(reviewId, transaction);
 
     if (hasComments) {
@@ -203,11 +195,7 @@ export async function deleteReview(serviceDto: DeleteReviewServiceDto): Promise<
     }
 
     await reviewRepository.deleteReview(review, transaction);
-    await transaction.commit();
+  });
 
-    logger.info('[REVIEWS SERVICE] review deleted', { reviewId, userId });
-  } catch (error) {
-    await transaction.rollback();
-    throw error;
-  }
+  logger.info('[REVIEWS SERVICE] review deleted', { reviewId, userId });
 }

--- a/server/src/utils/asyncHandler.ts
+++ b/server/src/utils/asyncHandler.ts
@@ -4,7 +4,7 @@ type AsyncControllerHandler<TReq extends Request = Request> = (
   req: TReq,
   res: Response,
   next: NextFunction
-) => Promise<unknown>;
+) => Promise<void>;
 
 /**
  * 非同期 controller ハンドラーの例外を `next` へ委譲する高階関数です。
@@ -17,7 +17,7 @@ type AsyncControllerHandler<TReq extends Request = Request> = (
  */
 export function asyncHandler<TReq extends Request = Request>(
   handler: AsyncControllerHandler<TReq>
-) {
-  return (req: Request, res: Response, next: NextFunction) =>
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return (req: Request, res: Response, next: NextFunction): Promise<void> =>
     handler(req as TReq, res, next).catch(next);
 }

--- a/server/src/utils/asyncHandler.ts
+++ b/server/src/utils/asyncHandler.ts
@@ -1,10 +1,10 @@
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
 
 type AsyncControllerHandler<TReq extends Request = Request> = (
   req: TReq,
   res: Response,
   next: NextFunction
-) => Promise<void>;
+) => Promise<unknown>;
 
 /**
  * 非同期 controller ハンドラーの例外を `next` へ委譲する高階関数です。
@@ -17,7 +17,7 @@ type AsyncControllerHandler<TReq extends Request = Request> = (
  */
 export function asyncHandler<TReq extends Request = Request>(
   handler: AsyncControllerHandler<TReq>
-): (req: Request, res: Response, next: NextFunction) => Promise<void> {
-  return (req: Request, res: Response, next: NextFunction): Promise<void> =>
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): Promise<unknown> =>
     handler(req as TReq, res, next).catch(next);
 }

--- a/server/src/utils/asyncHandler.ts
+++ b/server/src/utils/asyncHandler.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+
+type AsyncControllerHandler<TReq extends Request = Request> = (
+  req: TReq,
+  res: Response,
+  next: NextFunction
+) => Promise<unknown>;
+
+/**
+ * 非同期 controller ハンドラーの例外を `next` へ委譲する高階関数です。
+ *
+ * 各 controller で重複する `try/catch` を削減し、例外処理を
+ * `apiErrorHandler` へ一元化する目的で利用します。
+ *
+ * @param handler - 非同期 controller 本体
+ * @returns Express で利用できるハンドラー
+ */
+export function asyncHandler<TReq extends Request = Request>(
+  handler: AsyncControllerHandler<TReq>
+) {
+  return (req: Request, res: Response, next: NextFunction) =>
+    handler(req as TReq, res, next).catch(next);
+}

--- a/server/src/utils/mapper.ts
+++ b/server/src/utils/mapper.ts
@@ -1,4 +1,5 @@
 import type { CommentDto } from '../modules/comment/dto/comment.dto';
+import type { ReviewDto } from '../modules/review/dto/review.dto';
 
 // Model -> DTO 変換ユーティリティ
 // - Sequelize の model.toJSON() を受けて、API に返す形に整形します。
@@ -6,6 +7,10 @@ import type { CommentDto } from '../modules/comment/dto/comment.dto';
 
 // model.toJSON() を持つオブジェクトを受け取る想定
 type SerializableModel = { toJSON(): Record<string, unknown> };
+export type BookListRow = {
+  toJSON?: () => Record<string, unknown>;
+  get?: (key: string) => unknown;
+};
 
 // 値を安全に文字列/数値へ変換するヘルパー
 function asString(value: unknown): string {
@@ -15,7 +20,7 @@ function asString(value: unknown): string {
 function asNumberOrNull(value: unknown): number | null {
   if (value === undefined || value === null) return null;
   const n = Number(value);
-  return Number.isNaN(n) ? null : n;
+  return Number.isFinite(n) ? n : null;
 }
 
 // 日付文字列を ISO 8601 に変換し、無効な日時なら空文字を返す
@@ -54,5 +59,54 @@ export function commentModelToDto(m: SerializableModel): CommentDto {
     userId,
     createdAt,
     updatedAt,
+  };
+}
+
+/**
+ * Review Model（または toJSON を持つオブジェクト）を DTO へ変換します。
+ *
+ * @param model - Review モデル / plain object
+ * @returns API レスポンス向け ReviewDto
+ */
+export function reviewModelToDto(model: unknown): ReviewDto {
+  const json = (
+    typeof (model as { toJSON?: unknown }).toJSON === 'function'
+      ? (model as { toJSON: () => Record<string, unknown> }).toJSON()
+      : model
+  ) as Record<string, unknown>;
+
+  return {
+    id: Number(json.id),
+    bookId: Number(json.bookId),
+    userId: json.userId === null || json.userId === undefined ? null : Number(json.userId),
+    content: String(json.content),
+    rating: json.rating === undefined ? undefined : Number(json.rating),
+    createdAt: String(json.createdAt),
+    updatedAt: String(json.updatedAt),
+  };
+}
+
+/**
+ * 書籍一覧の 1 行を API レスポンス向けに正規化します。
+ *
+ * @param row - repository から返された書籍行
+ * @returns 集計列を正規化した書籍データ
+ */
+export function normalizeListBook(row: BookListRow): Record<string, unknown> & {
+  averageRating: number | null;
+  reviewCount: number;
+} {
+  const raw = typeof row.toJSON === 'function' ? row.toJSON() : (row as Record<string, unknown>);
+  const averageRatingValue =
+    raw.averageRating ?? (typeof row.get === 'function' ? row.get('averageRating') : undefined);
+  const reviewCountValue =
+    raw.reviewCount ?? (typeof row.get === 'function' ? row.get('reviewCount') : undefined);
+  const averageRating = asNumberOrNull(averageRatingValue);
+  const reviewCount = asNumberOrNull(reviewCountValue);
+
+  return {
+    ...raw,
+    averageRating,
+    reviewCount: reviewCount ?? 0,
   };
 }

--- a/server/src/utils/mapper.ts
+++ b/server/src/utils/mapper.ts
@@ -81,8 +81,8 @@ export function reviewModelToDto(model: unknown): ReviewDto {
     userId: json.userId === null || json.userId === undefined ? null : Number(json.userId),
     content: String(json.content),
     rating: json.rating === undefined ? undefined : Number(json.rating),
-    createdAt: String(json.createdAt),
-    updatedAt: String(json.updatedAt),
+    createdAt: formatDate(json.createdAt),
+    updatedAt: formatDate(json.updatedAt),
   };
 }
 

--- a/server/src/utils/sequelizeErrors.ts
+++ b/server/src/utils/sequelizeErrors.ts
@@ -10,6 +10,10 @@ type UniqueConstraintCandidate = {
   parent?: { sqlMessage?: string };
 };
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Sequelize の一意制約違反かどうかを判定します。
  *
@@ -68,7 +72,8 @@ export function isUniqueConstraintError(error: unknown, fields?: string[]): bool
     .toLowerCase();
 
   for (const field of targets) {
-    if (raw.includes(field)) {
+    const pattern = new RegExp(`\\b${escapeRegExp(field)}\\b`);
+    if (pattern.test(raw)) {
       return true;
     }
   }

--- a/server/src/utils/sequelizeErrors.ts
+++ b/server/src/utils/sequelizeErrors.ts
@@ -71,9 +71,23 @@ export function isUniqueConstraintError(error: unknown, fields?: string[]): bool
     .join(' ')
     .toLowerCase();
 
+  const isWordCharacter = (character: string): boolean => /[a-z0-9_]/.test(character);
+
+  const containsTargetField = (text: string, target: string): boolean => {
+    let index = text.indexOf(target);
+    while (index !== -1) {
+      const before = index === 0 || !isWordCharacter(text[index - 1]);
+      const after = index + target.length === text.length || !isWordCharacter(text[index + target.length]);
+      if (before && after) {
+        return true;
+      }
+      index = text.indexOf(target, index + 1);
+    }
+    return false;
+  };
+
   for (const field of targets) {
-    const pattern = new RegExp(`\\b${escapeRegExp(field)}\\b`);
-    if (pattern.test(raw)) {
+    if (containsTargetField(raw, field)) {
       return true;
     }
   }

--- a/server/src/utils/sequelizeErrors.ts
+++ b/server/src/utils/sequelizeErrors.ts
@@ -10,10 +10,6 @@ type UniqueConstraintCandidate = {
   parent?: { sqlMessage?: string };
 };
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * Sequelize の一意制約違反かどうかを判定します。
  *

--- a/server/src/utils/sequelizeErrors.ts
+++ b/server/src/utils/sequelizeErrors.ts
@@ -1,0 +1,77 @@
+import { UniqueConstraintError, ValidationErrorItem } from 'sequelize';
+
+type UniqueConstraintCandidate = {
+  name?: string;
+  errors?: Array<{ path?: string }>;
+  fields?: Record<string, unknown>;
+  message?: string;
+  sqlMessage?: string;
+  original?: { sqlMessage?: string };
+  parent?: { sqlMessage?: string };
+};
+
+/**
+ * Sequelize の一意制約違反かどうかを判定します。
+ *
+ * `fields` を指定した場合は、そのいずれかの項目に一致した場合のみ true を返します。
+ *
+ * @param error - 判定対象の例外
+ * @param fields - 対象カラム名（省略時は一意制約違反なら true）
+ * @returns 一意制約違反として扱うべき場合は true
+ */
+export function isUniqueConstraintError(error: unknown, fields?: string[]): boolean {
+  const targets = new Set((fields || []).map((field) => field.toLowerCase()));
+
+  const matches = (candidateFields: string[]) => {
+    if (targets.size === 0) {
+      return candidateFields.length > 0;
+    }
+    return candidateFields.some((field) => targets.has(field.toLowerCase()));
+  };
+
+  if (error instanceof UniqueConstraintError) {
+    const paths = error.errors.map((item: ValidationErrorItem) => item.path || '').filter(Boolean);
+    return matches(paths);
+  }
+
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const candidate = error as UniqueConstraintCandidate;
+  if (candidate.name !== 'SequelizeUniqueConstraintError') {
+    return false;
+  }
+
+  const pathFields = (candidate.errors || []).map((item) => item.path || '').filter(Boolean);
+  if (matches(pathFields)) {
+    return true;
+  }
+
+  const keyedFields = Object.keys(candidate.fields || {});
+  if (matches(keyedFields)) {
+    return true;
+  }
+
+  if (targets.size === 0) {
+    return true;
+  }
+
+  const raw = [
+    candidate.message,
+    candidate.sqlMessage,
+    candidate.original?.sqlMessage,
+    candidate.parent?.sqlMessage,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  for (const field of targets) {
+    if (raw.includes(field)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/server/tests/auth.controller.test.ts
+++ b/server/tests/auth.controller.test.ts
@@ -1,9 +1,8 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
 import { ApiError } from '../src/errors/ApiError';
-import { logger } from '../src/utils/logger';
 import { login, me, register } from '../src/controllers/auth.controller';
 import * as authService from '../src/services/auth.service';
 
@@ -34,6 +33,10 @@ function makeResponse(): MockResponse {
   return res;
 }
 
+function makeNext() {
+  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+}
+
 describe('auth.controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,8 +45,9 @@ describe('auth.controller', () => {
   it('register: バリデーションエラー時は 400 を返す', async () => {
     const req = makeRequest({ body: { username: 'a', email: 'bad', password: '123' } }); // NOSONAR
     const res = makeResponse();
+    const next = makeNext();
 
-    await register(req, res);
+    await register(req, res, next);
 
     expect(authService.register).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
@@ -60,13 +64,14 @@ describe('auth.controller', () => {
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
     });
     const res = makeResponse();
+    const next = makeNext();
     const data = {
       user: { id: 1, username: 'alice', email: 'alice@example.com' },
       token: 'token',
     };
     vi.mocked(authService.register).mockResolvedValue(data);
 
-    await register(req, res);
+    await register(req, res, next);
 
     expect(authService.register).toHaveBeenCalledWith({
       username: 'alice',
@@ -82,28 +87,23 @@ describe('auth.controller', () => {
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
     });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.register).mockRejectedValue(
       new ApiError(400, 'TEST_ERROR', 'test error', [{ field: 'email', message: 'invalid' }])
     );
 
-    await register(req, res);
+    await register(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: 'test error',
-        code: 'TEST_ERROR',
-        details: [{ field: 'email', message: 'invalid' }],
-      },
-    });
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('login: バリデーションエラー時は 400 を返す', async () => {
     const req = makeRequest({ body: { email: 'not-an-email', password: '' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await login(req, res);
+    await login(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(
@@ -117,10 +117,11 @@ describe('auth.controller', () => {
   it('login: 正常系では 200 を返す', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
+    const next = makeNext();
     const data = { token: 'token', user: { id: 1, username: 'alice', email: 'a@example.com' } };
     vi.mocked(authService.login).mockResolvedValue(data);
 
-    await login(req, res);
+    await login(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ success: true, data });
@@ -129,28 +130,23 @@ describe('auth.controller', () => {
   it('login: details 付き ApiError をそのまま返す', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.login).mockRejectedValue(
       new ApiError(400, 'TEST_ERROR', 'test error', [{ field: 'email', message: 'invalid' }])
     );
 
-    await login(req, res);
+    await login(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: 'test error',
-        code: 'TEST_ERROR',
-        details: [{ field: 'email', message: 'invalid' }],
-      },
-    });
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('me: 未認証時は 401 を返す', async () => {
     const req = makeRequest();
     const res = makeResponse();
+    const next = makeNext();
 
-    await me(req, res);
+    await me(req, res, next);
 
     expect(authService.getMyProfile).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
@@ -166,11 +162,12 @@ describe('auth.controller', () => {
   it('me: 正常系では 200 とプロフィールを返す', async () => {
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.getMyProfile).mockResolvedValue({
       user: { id: 7, username: 'me', email: 'me@example.com' },
     });
 
-    await me(req, res);
+    await me(req, res, next);
 
     expect(authService.getMyProfile).toHaveBeenCalledWith(7);
     expect(res.status).toHaveBeenCalledWith(200);
@@ -183,98 +180,66 @@ describe('auth.controller', () => {
   it('me: service の ApiError をそのまま返す', async () => {
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.getMyProfile).mockRejectedValue(
       new ApiError(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN_ADMIN_REQUIRED)
     );
 
-    await me(req, res);
+    await me(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.FORBIDDEN_ADMIN_REQUIRED,
-        code: 'FORBIDDEN',
-      },
-    });
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('me: 予期しない例外時は 500 を返す', async () => {
-    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.getMyProfile).mockRejectedValue(new Error('boom'));
 
-    await me(req, res);
+    await me(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
-    expect(loggerSpy).toHaveBeenCalledWith('[AUTH ME] unexpected error occurred');
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('register: 予期しない例外時は 500 を返す', async () => {
-    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
     });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.register).mockRejectedValue(new Error('boom'));
 
-    await register(req, res);
+    await register(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
-    expect(loggerSpy).toHaveBeenCalledWith('[AUTH REGISTER] unexpected error occurred');
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('login: 予期しない例外時は 500 を返す', async () => {
-    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.login).mockRejectedValue(new Error('boom'));
 
-    await login(req, res);
+    await login(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
-    expect(loggerSpy).toHaveBeenCalledWith('[AUTH LOGIN] unexpected error occurred');
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('login: details 付き ApiError をそのまま返す（重複ケース）', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(authService.login).mockRejectedValue(
       new ApiError(400, 'TEST_ERROR', 'test error', [{ field: 'email', message: 'invalid' }])
     );
 
-    await login(req, res);
+    await login(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: 'test error',
-        code: 'TEST_ERROR',
-        details: [{ field: 'email', message: 'invalid' }],
-      },
-    });
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 });

--- a/server/tests/auth.controller.test.ts
+++ b/server/tests/auth.controller.test.ts
@@ -33,8 +33,8 @@ function makeResponse(): MockResponse {
   return res;
 }
 
-function makeNext() {
-  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+function makeNext(): NextFunction {
+  return vi.fn() as unknown as NextFunction;
 }
 
 describe('auth.controller', () => {

--- a/server/tests/auth.controller.test.ts
+++ b/server/tests/auth.controller.test.ts
@@ -39,7 +39,7 @@ describe('auth.controller', () => {
     vi.clearAllMocks();
   });
 
-  it('register: returns 400 when validation fails', async () => {
+  it('register: バリデーションエラー時は 400 を返す', async () => {
     const req = makeRequest({ body: { username: 'a', email: 'bad', password: '123' } }); // NOSONAR
     const res = makeResponse();
 
@@ -55,7 +55,7 @@ describe('auth.controller', () => {
     );
   });
 
-  it('register: returns 201 on success', async () => {
+  it('register: 正常系では 201 を返す', async () => {
     const req = makeRequest({
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
     });
@@ -77,7 +77,7 @@ describe('auth.controller', () => {
     expect(res.json).toHaveBeenCalledWith({ success: true, data });
   });
 
-  it('register: forwards ApiError when service throws ApiError', async () => {
+  it('register: service の ApiError をそのまま返す', async () => {
     const req = makeRequest({
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
     });
@@ -94,11 +94,12 @@ describe('auth.controller', () => {
       error: {
         message: 'test error',
         code: 'TEST_ERROR',
+        details: [{ field: 'email', message: 'invalid' }],
       },
     });
   });
 
-  it('login: returns 400 when validation fails', async () => {
+  it('login: バリデーションエラー時は 400 を返す', async () => {
     const req = makeRequest({ body: { email: 'not-an-email', password: '' } });
     const res = makeResponse();
 
@@ -113,7 +114,7 @@ describe('auth.controller', () => {
     );
   });
 
-  it('login: returns 200 on success', async () => {
+  it('login: 正常系では 200 を返す', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
     const data = { token: 'token', user: { id: 1, username: 'alice', email: 'a@example.com' } };
@@ -125,7 +126,7 @@ describe('auth.controller', () => {
     expect(res.json).toHaveBeenCalledWith({ success: true, data });
   });
 
-  it('login: returns ApiError as-is even when details are present', async () => {
+  it('login: details 付き ApiError をそのまま返す', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
     vi.mocked(authService.login).mockRejectedValue(
@@ -140,11 +141,12 @@ describe('auth.controller', () => {
       error: {
         message: 'test error',
         code: 'TEST_ERROR',
+        details: [{ field: 'email', message: 'invalid' }],
       },
     });
   });
 
-  it('me: returns 401 when unauthenticated', async () => {
+  it('me: 未認証時は 401 を返す', async () => {
     const req = makeRequest();
     const res = makeResponse();
 
@@ -161,7 +163,7 @@ describe('auth.controller', () => {
     });
   });
 
-  it('me: returns 200 with profile on success', async () => {
+  it('me: 正常系では 200 とプロフィールを返す', async () => {
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
     vi.mocked(authService.getMyProfile).mockResolvedValue({
@@ -178,7 +180,7 @@ describe('auth.controller', () => {
     });
   });
 
-  it('me: forwards ApiError when service throws ApiError', async () => {
+  it('me: service の ApiError をそのまま返す', async () => {
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
     vi.mocked(authService.getMyProfile).mockRejectedValue(
@@ -197,7 +199,7 @@ describe('auth.controller', () => {
     });
   });
 
-  it('me: returns 500 when unexpected error occurs', async () => {
+  it('me: 予期しない例外時は 500 を返す', async () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ userId: 7 });
     const res = makeResponse();
@@ -216,7 +218,7 @@ describe('auth.controller', () => {
     expect(loggerSpy).toHaveBeenCalledWith('[AUTH ME] unexpected error occurred');
   });
 
-  it('register: returns 500 when unexpected error occurs', async () => {
+  it('register: 予期しない例外時は 500 を返す', async () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({
       body: { username: 'alice', email: 'alice@example.com', password: 'password123' }, // NOSONAR
@@ -237,7 +239,7 @@ describe('auth.controller', () => {
     expect(loggerSpy).toHaveBeenCalledWith('[AUTH REGISTER] unexpected error occurred');
   });
 
-  it('login: returns 500 when unexpected error occurs', async () => {
+  it('login: 予期しない例外時は 500 を返す', async () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
@@ -256,7 +258,7 @@ describe('auth.controller', () => {
     expect(loggerSpy).toHaveBeenCalledWith('[AUTH LOGIN] unexpected error occurred');
   });
 
-  it('login: returns ApiError as-is even when details are present', async () => {
+  it('login: details 付き ApiError をそのまま返す（重複ケース）', async () => {
     const req = makeRequest({ body: { email: 'a@example.com', password: 'password123' } }); // NOSONAR
     const res = makeResponse();
     vi.mocked(authService.login).mockRejectedValue(
@@ -271,6 +273,7 @@ describe('auth.controller', () => {
       error: {
         message: 'test error',
         code: 'TEST_ERROR',
+        details: [{ field: 'email', message: 'invalid' }],
       },
     });
   });

--- a/server/tests/auth.test.ts
+++ b/server/tests/auth.test.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
 import authRouter from '../src/routes/auth';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import User from '../src/models/Users';
 
 // このファイルの目的：認証関連ルートの正常系／異常系を確認するテスト
@@ -24,6 +25,7 @@ function makeApp(setUserId?: number) {
     next();
   });
   app.use('/api/auth', authRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
@@ -39,8 +41,8 @@ afterEach(() => {
 });
 
 // POST /api/auth/register のテスト
-describe('POST /api/auth/register', () => {
-  it('returns 400 when validation fails', async () => {
+describe('認証登録 API: POST /api/auth/register', () => {
+  it('バリデーションエラー時は 400 を返す', async () => {
     const res = await request(app).post('/api/auth/register').send({
       username: 'ab',
       email: 'bad',
@@ -51,7 +53,7 @@ describe('POST /api/auth/register', () => {
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
-  it('returns 409 when username already exists', async () => {
+  it('username 重複時は 409 を返す', async () => {
     // User.findOne をモックして「既存ユーザーあり」の挙動を再現
     vi.spyOn(User, 'findOne').mockResolvedValue({ id: 1 } as unknown as UserInstance);
 
@@ -65,7 +67,7 @@ describe('POST /api/auth/register', () => {
     expect(res.body.error.code).toBe('DUPLICATE_RESOURCE');
   });
 
-  it('returns 201 and token when registration succeeds', async () => {
+  it('登録成功時は 201 と token を返す', async () => {
     // bcrypt/hash, User.create, jwt.sign をモックして正常系を検証
     vi.spyOn(User, 'findOne').mockResolvedValue(null);
     vi.spyOn(bcrypt, 'hash').mockImplementation((async () => 'hashed') as typeof bcrypt.hash);
@@ -88,8 +90,8 @@ describe('POST /api/auth/register', () => {
 });
 
 // POST /api/auth/login のテスト
-describe('POST /api/auth/login', () => {
-  it('returns 400 when validation fails', async () => {
+describe('認証ログイン API: POST /api/auth/login', () => {
+  it('バリデーションエラー時は 400 を返す', async () => {
     const res = await request(app).post('/api/auth/login').send({
       email: 'bad',
       password: 'short',
@@ -99,7 +101,7 @@ describe('POST /api/auth/login', () => {
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
-  it('returns 401 when user not found', async () => {
+  it('ユーザー未存在時は 401 を返す', async () => {
     vi.spyOn(User, 'findOne').mockResolvedValue(null);
 
     const res = await request(app).post('/api/auth/login').send({
@@ -111,7 +113,7 @@ describe('POST /api/auth/login', () => {
     expect(res.body.error.code).toBe('AUTHENTICATION_FAILED');
   });
 
-  it('returns 401 when password is invalid', async () => {
+  it('パスワード不一致時は 401 を返す', async () => {
     // findOne, bcrypt.compare をモックしてパスワード不一致を再現
     vi.spyOn(User, 'findOne').mockResolvedValue({
       toJSON: () => ({ id: 1, username: 'u', email: 'u@example.com', password: 'hashed' }),
@@ -127,7 +129,7 @@ describe('POST /api/auth/login', () => {
     expect(res.body.error.code).toBe('AUTHENTICATION_FAILED');
   });
 
-  it('returns 200 and token when login succeeds', async () => {
+  it('ログイン成功時は 200 と token を返す', async () => {
     // 正常系：findOne, bcrypt.compare, jwt.sign をモック
     vi.spyOn(User, 'findOne').mockResolvedValue({
       toJSON: () => ({ id: 1, username: 'u', email: 'u@example.com', password: 'hashed' }),
@@ -147,14 +149,14 @@ describe('POST /api/auth/login', () => {
 });
 
 // GET /api/auth/me のテスト
-describe('GET /api/auth/me', () => {
-  it('returns 401 when unauthenticated', async () => {
+describe('プロフィール API: GET /api/auth/me', () => {
+  it('未認証時は 401 を返す', async () => {
     const res = await request(app).get('/api/auth/me');
     expect(res.status).toBe(401);
     expect(res.body.error.code).toBe('AUTHENTICATION_REQUIRED');
   });
 
-  it('returns 401 when authenticated user id is stale and user is not found', async () => {
+  it('認証済みでもユーザー未存在なら 401 を返す', async () => {
     const authApp = makeApp(123);
     vi.spyOn(User, 'findByPk').mockResolvedValue(null);
 
@@ -164,7 +166,7 @@ describe('GET /api/auth/me', () => {
     expect(res.body.error.code).toBe('USER_NOT_FOUND');
   });
 
-  it('returns 200 with user data when authenticated', async () => {
+  it('認証済みユーザーなら 200 で user を返す', async () => {
     const authApp = makeApp(5);
     vi.spyOn(User, 'findByPk').mockResolvedValue({
       toJSON: () => ({ id: 5, username: 'me', email: 'me@example.com' }),

--- a/server/tests/books-reviews.test.ts
+++ b/server/tests/books-reviews.test.ts
@@ -59,7 +59,7 @@ describe('GET /api/books/:bookId/reviews', () => {
     bookSpy.mockResolvedValue({ id: testBookId } as unknown as BookInstance);
 
     // reviewService.listReviews をモック
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
     reviewServiceSpy.mockResolvedValue({
       reviews: mockReviews,
       pagination: {
@@ -82,7 +82,7 @@ describe('GET /api/books/:bookId/reviews', () => {
     const bookSpy = vi.spyOn(Book, 'findByPk');
     bookSpy.mockResolvedValue({ id: testBookId } as unknown as BookInstance);
 
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
     reviewServiceSpy.mockResolvedValue({
       reviews: [],
       pagination: {
@@ -114,7 +114,7 @@ describe('GET /api/books/:bookId/reviews', () => {
     const testBookId = 1;
     vi.spyOn(Book, 'findByPk').mockResolvedValue({ id: testBookId } as unknown as BookInstance);
 
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
     reviewServiceSpy.mockResolvedValue({
       reviews: [],
       pagination: {
@@ -172,7 +172,7 @@ describe('GET /api/books/:bookId/reviews', () => {
     const bookSpy = vi.spyOn(Book, 'findByPk');
     bookSpy.mockResolvedValue({ id: testBookId } as unknown as BookInstance);
 
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
     reviewServiceSpy.mockResolvedValue({
       reviews: [],
       pagination: {
@@ -195,7 +195,7 @@ describe('GET /api/books/:bookId/reviews', () => {
     const bookSpy = vi.spyOn(Book, 'findByPk');
     bookSpy.mockResolvedValue({ id: testBookId } as unknown as BookInstance);
 
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
     reviewServiceSpy.mockResolvedValue({
       reviews: [],
       pagination: {
@@ -219,7 +219,7 @@ describe('GET /api/books/:bookId/reviews', () => {
   });
 
   it('page が 0 以下の場合は 400 を返す', async () => {
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
 
     const res = await request(app).get('/api/books/1/reviews').query({ page: -1 }).expect(400);
 
@@ -229,7 +229,7 @@ describe('GET /api/books/:bookId/reviews', () => {
   });
 
   it('limit が 0 以下の場合は 400 を返す', async () => {
-    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
+    const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews');
 
     const res = await request(app).get('/api/books/1/reviews').query({ limit: 0 }).expect(400);
 

--- a/server/tests/books-reviews.test.ts
+++ b/server/tests/books-reviews.test.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import request from 'supertest';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import type { SpyInstance } from 'vitest';
 
 import bookRouter from '../src/routes/books';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import Book from '../src/models/Book';
 import Review from '../src/models/Review';
 import * as reviewService from '../src/services/review.service';
@@ -19,6 +19,7 @@ function makeApp() {
   const app = express();
   app.use(express.json());
   app.use('/api/books', bookRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
@@ -37,8 +38,20 @@ describe('GET /api/books/:bookId/reviews', () => {
   it('特定書籍のレビュー一覧をページネーション付きで取得できる', async () => {
     const testBookId = 1;
     const mockReviews = [
-      { id: 1, bookId: testBookId, userId: 1, content: 'Great!', rating: 5 } as unknown as ReviewInstance,
-      { id: 2, bookId: testBookId, userId: 1, content: 'Good', rating: 4 } as unknown as ReviewInstance,
+      {
+        id: 1,
+        bookId: testBookId,
+        userId: 1,
+        content: 'Great!',
+        rating: 5,
+      } as unknown as ReviewInstance,
+      {
+        id: 2,
+        bookId: testBookId,
+        userId: 1,
+        content: 'Good',
+        rating: 4,
+      } as unknown as ReviewInstance,
     ];
 
     // Book.findByPk をモック
@@ -57,9 +70,7 @@ describe('GET /api/books/:bookId/reviews', () => {
       },
     });
 
-    const res = await request(app)
-      .get(`/api/books/${testBookId}/reviews`)
-      .expect(200);
+    const res = await request(app).get(`/api/books/${testBookId}/reviews`).expect(200);
 
     expect(res.body.success).toBe(true);
     expect(res.body.data.reviews).toHaveLength(2);
@@ -114,10 +125,7 @@ describe('GET /api/books/:bookId/reviews', () => {
       },
     });
 
-    await request(app)
-      .get(`/api/books/${testBookId}/reviews`)
-      .query({ limit: 500 })
-      .expect(200);
+    await request(app).get(`/api/books/${testBookId}/reviews`).query({ limit: 500 }).expect(200);
 
     expect(reviewServiceSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -129,9 +137,7 @@ describe('GET /api/books/:bookId/reviews', () => {
   });
 
   it('無効な書籍 ID（非整数）を返す場合 400 エラー', async () => {
-    const res = await request(app)
-      .get('/api/books/invalid/reviews')
-      .expect(400);
+    const res = await request(app).get('/api/books/invalid/reviews').expect(400);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('INVALID_BOOK_ID');
@@ -141,27 +147,21 @@ describe('GET /api/books/:bookId/reviews', () => {
     const bookSpy = vi.spyOn(Book, 'findByPk');
     bookSpy.mockResolvedValue(null);
 
-    const res = await request(app)
-      .get('/api/books/99999/reviews')
-      .expect(404);
+    const res = await request(app).get('/api/books/99999/reviews').expect(404);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('BOOK_NOT_FOUND');
   });
 
   it('負の書籍 ID を返す場合 400 エラー', async () => {
-    const res = await request(app)
-      .get('/api/books/-1/reviews')
-      .expect(400);
+    const res = await request(app).get('/api/books/-1/reviews').expect(400);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('INVALID_BOOK_ID');
   });
 
   it('0 の書籍 ID を返す場合 400 エラー', async () => {
-    const res = await request(app)
-      .get('/api/books/0/reviews')
-      .expect(400);
+    const res = await request(app).get('/api/books/0/reviews').expect(400);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('INVALID_BOOK_ID');
@@ -183,16 +183,14 @@ describe('GET /api/books/:bookId/reviews', () => {
       },
     });
 
-    const res = await request(app)
-      .get(`/api/books/${testBookId}/reviews`)
-      .expect(200);
+    const res = await request(app).get(`/api/books/${testBookId}/reviews`).expect(200);
 
     expect(res.body.success).toBe(true);
     expect(res.body.data.reviews).toEqual([]);
     expect(res.body.data.pagination.totalItems).toBe(0);
   });
 
-  it('デフォルトページペーションパラメータ（page=1, limit=20）が設定される', async () => {
+  it('デフォルトページング（page=1, limit=20）が設定される', async () => {
     const testBookId = 1;
     const bookSpy = vi.spyOn(Book, 'findByPk');
     bookSpy.mockResolvedValue({ id: testBookId } as unknown as BookInstance);
@@ -208,9 +206,7 @@ describe('GET /api/books/:bookId/reviews', () => {
       },
     });
 
-    await request(app)
-      .get(`/api/books/${testBookId}/reviews`)
-      .expect(200);
+    await request(app).get(`/api/books/${testBookId}/reviews`).expect(200);
 
     // デフォルト値で呼ばれたことを確認
     expect(reviewServiceSpy).toHaveBeenCalledWith(
@@ -225,10 +221,7 @@ describe('GET /api/books/:bookId/reviews', () => {
   it('page が 0 以下の場合は 400 を返す', async () => {
     const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
 
-    const res = await request(app)
-      .get('/api/books/1/reviews')
-      .query({ page: -1 })
-      .expect(400);
+    const res = await request(app).get('/api/books/1/reviews').query({ page: -1 }).expect(400);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('INVALID_PAGE');
@@ -238,10 +231,7 @@ describe('GET /api/books/:bookId/reviews', () => {
   it('limit が 0 以下の場合は 400 を返す', async () => {
     const reviewServiceSpy = vi.spyOn(reviewService, 'listReviews') as unknown as SpyInstance;
 
-    const res = await request(app)
-      .get('/api/books/1/reviews')
-      .query({ limit: 0 })
-      .expect(400);
+    const res = await request(app).get('/api/books/1/reviews').query({ limit: 0 }).expect(400);
 
     expect(res.body.success).toBe(false);
     expect(res.body.error.code).toBe('INVALID_LIMIT');

--- a/server/tests/books.test.ts
+++ b/server/tests/books.test.ts
@@ -21,6 +21,7 @@ import User from '../src/models/Users';
 import { sequelize } from '../src/sequelize';
 import * as bookService from '../src/services/book.service';
 import { ApiError } from '../src/errors/ApiError';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 
 // このファイルの目的：書籍 API の CRUD とページネーションを検証するテスト
 // - findAndCountAll のモックを用いてページング動作を確認
@@ -44,6 +45,7 @@ function makeApp() {
   const app = express();
   app.use(express.json());
   app.use('/api/books', bookRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 

--- a/server/tests/comment.controller.test.ts
+++ b/server/tests/comment.controller.test.ts
@@ -40,7 +40,7 @@ function makeResponse(): MockResponse {
 }
 
 function makeNext() {
-  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+  return vi.fn<NextFunction>();
 }
 
 describe('comment.controller', () => {
@@ -89,6 +89,8 @@ describe('comment.controller', () => {
     await listComments(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
   });
 
   it('listComments: returns 500 when service fails', async () => {
@@ -100,6 +102,8 @@ describe('comment.controller', () => {
     await listComments(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
   });
 
   it('createComment: returns 401 when unauthenticated', async () => {
@@ -149,6 +153,8 @@ describe('comment.controller', () => {
     await createComment(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
   });
 
   it('createComment: returns 500 when service fails', async () => {
@@ -160,5 +166,7 @@ describe('comment.controller', () => {
     await createComment(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/comment.controller.test.ts
+++ b/server/tests/comment.controller.test.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
@@ -39,8 +40,8 @@ function makeResponse(): MockResponse {
   return res;
 }
 
-function makeNext() {
-  return vi.fn<NextFunction>();
+function makeNext(): NextFunction {
+  return vi.fn() as unknown as NextFunction;
 }
 
 describe('comment.controller', () => {

--- a/server/tests/comment.controller.test.ts
+++ b/server/tests/comment.controller.test.ts
@@ -1,9 +1,8 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
 import { ApiError } from '../src/errors/ApiError';
-import { logger } from '../src/utils/logger';
 import { createComment, listComments } from '../src/controllers/comment.controller';
 import * as commentService from '../src/services/comment.service';
 
@@ -40,6 +39,10 @@ function makeResponse(): MockResponse {
   return res;
 }
 
+function makeNext() {
+  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+}
+
 describe('comment.controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -48,8 +51,9 @@ describe('comment.controller', () => {
   it('listComments: returns 400 for invalid reviewId', async () => {
     const req = makeRequest({ params: { reviewId: 'abc' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await listComments(req, res);
+    await listComments(req, res, next);
 
     expect(commentService.listComments).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
@@ -64,10 +68,11 @@ describe('comment.controller', () => {
   it('listComments: returns comments on success', async () => {
     const req = makeRequest({ params: { reviewId: '3' } });
     const res = makeResponse();
+    const next = makeNext();
     const comments = [{ id: 1, content: 'nice' }];
     vi.mocked(commentService.listComments).mockResolvedValue(comments as never);
 
-    await listComments(req, res);
+    await listComments(req, res, next);
 
     expect(commentService.listComments).toHaveBeenCalledWith(3);
     expect(res.json).toHaveBeenCalledWith({ success: true, data: { comments } });
@@ -76,43 +81,33 @@ describe('comment.controller', () => {
   it('listComments: forwards ApiError', async () => {
     const req = makeRequest({ params: { reviewId: '3' } });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(commentService.listComments).mockRejectedValue(
       new ApiError(404, 'NOT_FOUND', ERROR_MESSAGES.NOT_FOUND)
     );
 
-    await listComments(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.NOT_FOUND,
-        code: 'NOT_FOUND',
-      },
-    });
+    await listComments(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('listComments: returns 500 when service fails', async () => {
-    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ params: { reviewId: '3' } });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(commentService.listComments).mockRejectedValue(new Error('boom'));
 
-    await listComments(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
-    });
-    expect(loggerSpy).toHaveBeenCalledWith('[COMMENTS GET] unexpected error occurred');
+    await listComments(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('createComment: returns 401 when unauthenticated', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'x' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await createComment(req, res);
+    await createComment(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
@@ -127,8 +122,9 @@ describe('comment.controller', () => {
   it('createComment: returns 400 when validation fails', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: '' }, userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
 
-    await createComment(req, res);
+    await createComment(req, res, next);
 
     expect(commentService.createComment).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
@@ -143,38 +139,26 @@ describe('comment.controller', () => {
   it('createComment: forwards ApiError with details', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'ok' }, userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(commentService.createComment).mockRejectedValue(
       new ApiError(400, 'VALIDATION_ERROR', ERROR_MESSAGES.VALIDATION_FAILED, [
         { field: 'parentId', message: ERROR_MESSAGES.PARENT_COMMENT_NOT_FOUND },
       ])
     );
 
-    await createComment(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.VALIDATION_FAILED,
-        code: 'VALIDATION_ERROR',
-        details: [{ field: 'parentId', message: ERROR_MESSAGES.PARENT_COMMENT_NOT_FOUND }],
-      },
-    });
+    await createComment(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('createComment: returns 500 when service fails', async () => {
-    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'ok' }, userId: 7 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(commentService.createComment).mockRejectedValue(new Error('boom'));
 
-    await createComment(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR, code: 'INTERNAL_SERVER_ERROR' },
-    });
-    expect(loggerSpy).toHaveBeenCalledWith('[COMMENTS POST] unexpected error occurred');
+    await createComment(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/server/tests/comment.service.test.ts
+++ b/server/tests/comment.service.test.ts
@@ -1,30 +1,39 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as commentService from '../src/services/comment.service';
-import Review from '../src/models/Review';
-import Comment from '../src/models/Comment';
-import { logger } from '../src/utils/logger';
 import type { CreateCommentServiceDto } from '../src/modules/comment/dto/comment.dto';
+import * as commentRepository from '../src/repositories/comment.repository';
+import * as reviewRepository from '../src/repositories/review.repository';
+import * as commentService from '../src/services/comment.service';
+import { logger } from '../src/utils/logger';
 
-// Sequelize インスタンス型を定義
-type CommentInstance = InstanceType<typeof Comment>;
+vi.mock('../src/repositories/comment.repository', () => ({
+  findCommentsByReviewId: vi.fn(),
+  findCommentById: vi.fn(),
+  createComment: vi.fn(),
+}));
 
-// モデルメソッドを spy して外部依存を排除
+vi.mock('../src/repositories/review.repository', () => ({
+  findReviewById: vi.fn(),
+}));
+
+function makeCommentModel(input: Record<string, unknown>) {
+  return {
+    toJSON: () => input,
+    get: (key: string) => input[key],
+  };
+}
 
 describe('comment.service', () => {
   beforeEach(() => {
-    // 各テスト用に spy をリセット
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('listComments', () => {
     it('returns nested replies in correct order and logs activity', async () => {
-      // logger.info のスパイ設定
       const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
 
-      // 親コメント（parentId: null）をモック
-      const parent = {
-        toJSON: () => ({
+      vi.mocked(commentRepository.findCommentsByReviewId).mockResolvedValue([
+        makeCommentModel({
           id: 1,
           content: 'parent',
           parentId: null,
@@ -32,11 +41,8 @@ describe('comment.service', () => {
           userId: 2,
           createdAt: '2025-01-01T00:00:00.000Z',
           updatedAt: '2025-01-02T00:00:00.000Z',
-        }),
-      } as unknown as Comment;
-      // 返信コメント（parentId: 1）をモック
-      const reply = {
-        toJSON: () => ({
+        }) as never,
+        makeCommentModel({
           id: 2,
           content: 'reply',
           parentId: 1,
@@ -44,21 +50,14 @@ describe('comment.service', () => {
           userId: 3,
           createdAt: '2025-01-03T00:00:00.000Z',
           updatedAt: '2025-01-04T00:00:00.000Z',
-        }),
-      } as unknown as Comment;
+        }) as never,
+      ]);
 
-      // Comment.findAll をモック化
-      vi.spyOn(Comment, 'findAll').mockResolvedValue([parent, reply] as unknown as CommentInstance[]);
-
-      // listComments を実行
       const result = await commentService.listComments(10);
 
-      // logger.info が呼ばれたことを確認
       expect(infoSpy).toHaveBeenCalled();
-      // 親コメントのみが結果に含まれる（返信はネストされる）
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe(1);
-      // 返信コメントがネストされていることを確認
       expect(result[0].replies).toHaveLength(1);
       expect(result[0].replies?.[0].id).toBe(2);
     });
@@ -66,19 +65,17 @@ describe('comment.service', () => {
 
   describe('createComment', () => {
     it('throws REVIEW_NOT_FOUND when review does not exist', async () => {
-      // Review が見つからないようにモック
-      vi.spyOn(Review, 'findByPk').mockResolvedValue(null);
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue(null);
 
       const dto: CreateCommentServiceDto = { reviewId: 123, content: 'x', userId: 1 };
-      // REVIEW_NOT_FOUND エラーが投げられることを確認
-      await expect(commentService.createComment(dto)).rejects.toMatchObject({ code: 'REVIEW_NOT_FOUND' });
+      await expect(commentService.createComment(dto)).rejects.toMatchObject({
+        code: 'REVIEW_NOT_FOUND',
+      });
     });
 
     it('throws VALIDATION_ERROR when parent comment is missing', async () => {
-      // Review は存在することをモック（型安全なキャスト）
-      vi.spyOn(Review, 'findByPk').mockResolvedValue({} as unknown as InstanceType<typeof Review>);
-      // 親コメント（parentId: 99）が見つからないようにモック
-      vi.spyOn(Comment, 'findByPk').mockResolvedValue(null);
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue({} as never);
+      vi.mocked(commentRepository.findCommentById).mockResolvedValue(null);
 
       const dto: CreateCommentServiceDto = {
         reviewId: 1,
@@ -86,16 +83,17 @@ describe('comment.service', () => {
         userId: 5,
         parentId: 99,
       };
-      // 親コメントが見つからないため VALIDATION_ERROR が投げられることを確認
-      await expect(commentService.createComment(dto)).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+      await expect(commentService.createComment(dto)).rejects.toMatchObject({
+        code: 'VALIDATION_ERROR',
+      });
     });
 
     it('throws VALIDATION_ERROR when parent belongs to another review', async () => {
-      // Review は存在することをモック
-      vi.spyOn(Review, 'findByPk').mockResolvedValue({} as unknown as InstanceType<typeof Review>);
-      // 親コメントは異なる reviewId（888）を持つようにモック
-      const parentCommentMock = { get: () => 888 } as unknown as InstanceType<typeof Comment>;
-      vi.spyOn(Comment, 'findByPk').mockResolvedValue(parentCommentMock);
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue({} as never);
+      vi.mocked(commentRepository.findCommentById).mockResolvedValue(
+        makeCommentModel({ reviewId: 888 }) as never
+      );
 
       const dto: CreateCommentServiceDto = {
         reviewId: 10,
@@ -103,21 +101,21 @@ describe('comment.service', () => {
         userId: 5,
         parentId: 7,
       };
-      // 親コメントが別のレビューに属するため VALIDATION_ERROR が投げられることを確認
-      await expect(commentService.createComment(dto)).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+
+      await expect(commentService.createComment(dto)).rejects.toMatchObject({
+        code: 'VALIDATION_ERROR',
+      });
     });
 
     it('creates a comment when all conditions are satisfied', async () => {
-      // logger.info のスパイ設定
       const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
-      // Review は存在することをモック
-      vi.spyOn(Review, 'findByPk').mockResolvedValue({} as unknown as InstanceType<typeof Review>);
-      // 親コメントのレビュー ID（10）がリクエストのレビュー ID と一致するようにモック
-      const parentCommentMock = { get: () => 10 } as unknown as InstanceType<typeof Comment>;
-      vi.spyOn(Comment, 'findByPk').mockResolvedValue(parentCommentMock);
-      // 作成されたコメントのモック
-      const created = {
-        toJSON: () => ({
+
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue({} as never);
+      vi.mocked(commentRepository.findCommentById).mockResolvedValue(
+        makeCommentModel({ reviewId: 10 }) as never
+      );
+      vi.mocked(commentRepository.createComment).mockResolvedValue(
+        makeCommentModel({
           id: 77,
           content: 'created',
           parentId: null,
@@ -125,28 +123,24 @@ describe('comment.service', () => {
           userId: 2,
           createdAt: '2025-05-05T00:00:00.000Z',
           updatedAt: '2025-05-05T00:00:00.000Z',
-        }),
-        get: (key: string) => {
-          if (key === 'id') return 77;
-          return undefined;
-        },
-      } as unknown as Comment;
-      // Comment.create をモック化
-      vi.spyOn(Comment, 'create').mockResolvedValue(created);
+        }) as never
+      );
 
-      // コメント作成を実行
       const dto = await commentService.createComment({
         reviewId: 10,
         content: 'created',
         userId: 2,
         parentId: null,
-      } as CreateCommentServiceDto);
+      });
 
-      // logger が呼ばれたことを確認
       expect(infoSpy).toHaveBeenCalled();
-      // 作成されたコメントの ID を確認
+      expect(commentRepository.createComment).toHaveBeenCalledWith({
+        content: 'created',
+        reviewId: 10,
+        parentId: null,
+        userId: 2,
+      });
       expect(dto.id).toBe(77);
-      // 作成されたコメントの内容を確認
       expect(dto.content).toBe('created');
     });
   });

--- a/server/tests/mapper.test.ts
+++ b/server/tests/mapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { commentModelToDto } from '../src/utils/mapper';
+import { commentModelToDto, normalizeListBook, reviewModelToDto } from '../src/utils/mapper';
 
 // 内部ヘルパーはエクスポートされていないため、各ケースを commentModelToDto 経由で
 // テストします。
@@ -56,5 +56,41 @@ describe('mapper utilities', () => {
     // 日時は formatDate 関数がエラーを抑制して空文字列を返す
     expect(dto.createdAt).toBe('');
     expect(dto.updatedAt).toBe('');
+  });
+
+  it('reviewModelToDto が Review モデルを DTO へ変換できる', () => {
+    const dto = reviewModelToDto({
+      toJSON: () => ({
+        id: '11',
+        bookId: '20',
+        userId: '3',
+        content: 'review text',
+        rating: '4',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      }),
+    });
+
+    expect(dto).toMatchObject({
+      id: 11,
+      bookId: 20,
+      userId: 3,
+      content: 'review text',
+      rating: 4,
+    });
+  });
+
+  it('normalizeListBook が集計列を API 返却用に正規化する', () => {
+    const normalized = normalizeListBook({
+      toJSON: () => ({
+        id: 1,
+        title: 'Book A',
+        averageRating: '4.5',
+        reviewCount: null,
+      }),
+    });
+
+    expect(normalized.averageRating).toBe(4.5);
+    expect(normalized.reviewCount).toBe(0);
   });
 });

--- a/server/tests/review.controller.test.ts
+++ b/server/tests/review.controller.test.ts
@@ -52,8 +52,8 @@ function makeResponse(): MockResponse {
   return res;
 }
 
-function makeNext() {
-  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+function makeNext(): NextFunction {
+  return vi.fn() as unknown as NextFunction;
 }
 
 describe('review.controller', () => {

--- a/server/tests/review.controller.test.ts
+++ b/server/tests/review.controller.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
@@ -52,6 +52,10 @@ function makeResponse(): MockResponse {
   return res;
 }
 
+function makeNext() {
+  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+}
+
 describe('review.controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,8 +64,9 @@ describe('review.controller', () => {
   it('listReviews: returns 400 when query validation fails', async () => {
     const req = makeRequest({ query: { bookId: 'abc' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await listReviews(req, res);
+    await listReviews(req, res, next);
 
     expect(reviewService.listReviews).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
@@ -76,10 +81,11 @@ describe('review.controller', () => {
   it('listReviews: returns data on success', async () => {
     const req = makeRequest({ query: { bookId: '1' } });
     const res = makeResponse();
+    const next = makeNext();
     const data = { reviews: [], pagination: { page: 1, totalItems: 0, totalPages: 0 } };
     vi.mocked(reviewService.listReviews).mockResolvedValue(data as never);
 
-    await listReviews(req, res);
+    await listReviews(req, res, next);
 
     expect(reviewService.listReviews).toHaveBeenCalledWith({ bookId: 1, page: 1, limit: 20 });
     expect(res.json).toHaveBeenCalledWith({ success: true, data });
@@ -88,29 +94,24 @@ describe('review.controller', () => {
   it('listReviews: forwards ApiError', async () => {
     const req = makeRequest({ query: { bookId: '1' } });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.listReviews).mockRejectedValue(
       new ApiError(404, 'NOT_FOUND', ERROR_MESSAGES.NOT_FOUND)
     );
 
-    await listReviews(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.NOT_FOUND,
-        code: 'NOT_FOUND',
-      },
-    });
+    await listReviews(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('getReviewDetail: returns data on success', async () => {
     const req = makeRequest({ params: { reviewId: '1' } });
     const res = makeResponse();
+    const next = makeNext();
     const data = { id: 1, bookId: 10, content: 'text', createdAt: 'x', updatedAt: 'x' };
     vi.mocked(reviewService.getReviewDetail).mockResolvedValue(data as never);
 
-    await getReviewDetail(req, res);
+    await getReviewDetail(req, res, next);
 
     expect(reviewService.getReviewDetail).toHaveBeenCalledWith(1);
     expect(res.json).toHaveBeenCalledWith({ success: true, data });
@@ -119,27 +120,22 @@ describe('review.controller', () => {
   it('getReviewDetail: returns 500 when service fails', async () => {
     const req = makeRequest({ params: { reviewId: '1' } });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.getReviewDetail).mockRejectedValue(new Error('boom'));
 
-    await getReviewDetail(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
+    await getReviewDetail(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('createReview: returns 201 on success', async () => {
     const req = makeRequest({ body: { bookId: 1, content: 'x' }, userId: 2 });
     const res = makeResponse();
+    const next = makeNext();
     const created = { id: 1, bookId: 1, content: 'x' } as const;
     vi.mocked(reviewService.createReview).mockResolvedValue(created as never);
 
-    await createReview(req, res);
+    await createReview(req, res, next);
 
     expect(reviewService.createReview).toHaveBeenCalledWith({ bookId: 1, content: 'x', userId: 2 });
     expect(res.status).toHaveBeenCalledWith(201);
@@ -149,25 +145,20 @@ describe('review.controller', () => {
   it('createReview: returns 500 when service fails', async () => {
     const req = makeRequest({ body: { bookId: 1, content: 'x' }, userId: 2 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.createReview).mockRejectedValue(new Error('boom'));
 
-    await createReview(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
+    await createReview(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('createReview: returns 401 when unauthenticated', async () => {
     const req = makeRequest({ body: { bookId: 1, content: 'x' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await createReview(req, res);
+    await createReview(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
@@ -182,8 +173,9 @@ describe('review.controller', () => {
   it('updateReview: returns 401 when unauthenticated', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'new' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await updateReview(req, res);
+    await updateReview(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
@@ -198,27 +190,22 @@ describe('review.controller', () => {
   it('updateReview: forwards ApiError', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'new' }, userId: 2 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.updateReview).mockRejectedValue(
       new ApiError(403, 'FORBIDDEN', ERROR_MESSAGES.FORBIDDEN_REVIEW_UPDATE)
     );
 
-    await updateReview(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.FORBIDDEN_REVIEW_UPDATE,
-        code: 'FORBIDDEN',
-      },
-    });
+    await updateReview(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('updateReview: returns 400 when reviewId is invalid', async () => {
     const req = makeRequest({ params: { reviewId: 'abc' }, body: { content: 'new' }, userId: 2 });
     const res = makeResponse();
+    const next = makeNext();
 
-    await updateReview(req, res);
+    await updateReview(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(
@@ -232,25 +219,20 @@ describe('review.controller', () => {
   it('updateReview: returns 500 when service fails', async () => {
     const req = makeRequest({ params: { reviewId: '1' }, body: { content: 'new' }, userId: 2 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.updateReview).mockRejectedValue(new Error('boom'));
 
-    await updateReview(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
+    await updateReview(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('deleteReview: returns 401 when unauthenticated', async () => {
     const req = makeRequest({ params: { reviewId: '2' } });
     const res = makeResponse();
+    const next = makeNext();
 
-    await deleteReview(req, res);
+    await deleteReview(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
@@ -265,8 +247,9 @@ describe('review.controller', () => {
   it('deleteReview: returns 400 when reviewId is invalid', async () => {
     const req = makeRequest({ params: { reviewId: 'abc' }, userId: 1 });
     const res = makeResponse();
+    const next = makeNext();
 
-    await deleteReview(req, res);
+    await deleteReview(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(
@@ -280,26 +263,21 @@ describe('review.controller', () => {
   it('deleteReview: returns 500 when service fails', async () => {
     const req = makeRequest({ params: { reviewId: '2' }, userId: 5 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.deleteReview).mockRejectedValue(new Error('boom'));
 
-    await deleteReview(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        code: 'INTERNAL_SERVER_ERROR',
-      },
-    });
+    await deleteReview(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it('deleteReview: returns 204 on success', async () => {
     const req = makeRequest({ params: { reviewId: '2' }, userId: 5 });
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(reviewService.deleteReview).mockResolvedValue(undefined);
 
-    await deleteReview(req, res);
+    await deleteReview(req, res, next);
 
     expect(reviewService.deleteReview).toHaveBeenCalledWith({ reviewId: 2, userId: 5 });
     expect(res.sendStatus).toHaveBeenCalledWith(204);

--- a/server/tests/review.service.test.ts
+++ b/server/tests/review.service.test.ts
@@ -1,18 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as bookRepository from '../src/repositories/book.repository';
 import * as reviewRepository from '../src/repositories/review.repository';
+import { sequelize } from '../src/sequelize';
 import * as reviewService from '../src/services/review.service';
+
+vi.mock('../src/repositories/book.repository', () => ({
+  findBookById: vi.fn(),
+}));
 
 vi.mock('../src/repositories/review.repository', () => ({
   findReviewsWithPagination: vi.fn(),
   findReviewDetailById: vi.fn(),
   findReviewById: vi.fn(),
-  findBookById: vi.fn(),
   createReview: vi.fn(),
   updateReviewContent: vi.fn(),
   findAnyCommentByReviewId: vi.fn(),
   deleteReview: vi.fn(),
-  createTransaction: vi.fn(),
+}));
+
+vi.mock('../src/sequelize', () => ({
+  sequelize: {
+    transaction: vi.fn(),
+  },
 }));
 
 function makeReviewModel(input: Record<string, unknown>) {
@@ -47,9 +57,9 @@ describe('review.service', () => {
       const result = await reviewService.listReviews({ page: 2, limit: 10, bookId: 3 });
 
       expect(reviewRepository.findReviewsWithPagination).toHaveBeenCalledWith({
-        where: { bookId: 3 },
+        page: 2,
         limit: 10,
-        offset: 10,
+        bookId: 3,
       });
       expect(result.pagination).toEqual({
         currentPage: 2,
@@ -63,7 +73,7 @@ describe('review.service', () => {
 
   describe('createReview', () => {
     it('throws 404 when book does not exist', async () => {
-      vi.mocked(reviewRepository.findBookById).mockResolvedValue(null);
+      vi.mocked(bookRepository.findBookById).mockResolvedValue(null);
 
       await expect(
         reviewService.createReview({ bookId: 1, content: 'x', rating: 5, userId: 1 })
@@ -71,7 +81,7 @@ describe('review.service', () => {
     });
 
     it('creates review when book exists', async () => {
-      vi.mocked(reviewRepository.findBookById).mockResolvedValue({} as never);
+      vi.mocked(bookRepository.findBookById).mockResolvedValue({} as never);
       vi.mocked(reviewRepository.createReview).mockResolvedValue(
         makeReviewModel({
           id: 2,
@@ -84,7 +94,12 @@ describe('review.service', () => {
         }) as never
       );
 
-      const result = await reviewService.createReview({ bookId: 1, content: 'nice', rating: 4, userId: 1 });
+      const result = await reviewService.createReview({
+        bookId: 1,
+        content: 'nice',
+        rating: 4,
+        userId: 1,
+      });
 
       expect(reviewRepository.createReview).toHaveBeenCalledWith({
         bookId: 1,
@@ -93,6 +108,45 @@ describe('review.service', () => {
         rating: 4,
       });
       expect(result.id).toBe(2);
+    });
+  });
+
+  describe('deleteReview', () => {
+    it('deletes review inside a sequelize transaction when no related comments exist', async () => {
+      const transaction = { id: 'tx' };
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
+        makeReviewModel({ id: 3, userId: 7 }) as never
+      );
+      vi.mocked(reviewRepository.findAnyCommentByReviewId).mockResolvedValue(null);
+      vi.mocked(sequelize.transaction).mockImplementation(async (callback) => {
+        return callback(transaction as never);
+      });
+
+      await reviewService.deleteReview({ reviewId: 3, userId: 7 });
+
+      expect(sequelize.transaction).toHaveBeenCalledTimes(1);
+      expect(reviewRepository.findAnyCommentByReviewId).toHaveBeenCalledWith(3, transaction);
+      expect(reviewRepository.deleteReview).toHaveBeenCalledWith(
+        expect.objectContaining({ get: expect.any(Function) }),
+        transaction
+      );
+    });
+
+    it('throws 409 when related comments exist', async () => {
+      const transaction = { id: 'tx' };
+      vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
+        makeReviewModel({ id: 3, userId: 7 }) as never
+      );
+      vi.mocked(reviewRepository.findAnyCommentByReviewId).mockResolvedValue({ id: 99 } as never);
+      vi.mocked(sequelize.transaction).mockImplementation(async (callback) => {
+        return callback(transaction as never);
+      });
+
+      await expect(reviewService.deleteReview({ reviewId: 3, userId: 7 })).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'RELATED_DATA_EXISTS',
+      });
+      expect(reviewRepository.deleteReview).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/tests/review.service.test.ts
+++ b/server/tests/review.service.test.ts
@@ -113,14 +113,12 @@ describe('review.service', () => {
 
   describe('deleteReview', () => {
     it('deletes review inside a sequelize transaction when no related comments exist', async () => {
-      const transaction = { id: 'tx' };
+      const transaction = { id: 'tx', commit: vi.fn(), rollback: vi.fn() };
       vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
         makeReviewModel({ id: 3, userId: 7 }) as never
       );
       vi.mocked(reviewRepository.findAnyCommentByReviewId).mockResolvedValue(null);
-      vi.mocked(sequelize.transaction).mockImplementation(async (callback) => {
-        return callback(transaction as never);
-      });
+      vi.mocked(sequelize.transaction).mockResolvedValue(transaction as never);
 
       await reviewService.deleteReview({ reviewId: 3, userId: 7 });
 
@@ -130,23 +128,23 @@ describe('review.service', () => {
         expect.objectContaining({ get: expect.any(Function) }),
         transaction
       );
+      expect(transaction.commit).toHaveBeenCalled();
     });
 
     it('throws 409 when related comments exist', async () => {
-      const transaction = { id: 'tx' };
+      const transaction = { id: 'tx', commit: vi.fn(), rollback: vi.fn() };
       vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
         makeReviewModel({ id: 3, userId: 7 }) as never
       );
       vi.mocked(reviewRepository.findAnyCommentByReviewId).mockResolvedValue({ id: 99 } as never);
-      vi.mocked(sequelize.transaction).mockImplementation(async (callback) => {
-        return callback(transaction as never);
-      });
+      vi.mocked(sequelize.transaction).mockResolvedValue(transaction as never);
 
       await expect(reviewService.deleteReview({ reviewId: 3, userId: 7 })).rejects.toMatchObject({
         statusCode: 409,
         code: 'RELATED_DATA_EXISTS',
       });
       expect(reviewRepository.deleteReview).not.toHaveBeenCalled();
+      expect(transaction.rollback).toHaveBeenCalled();
     });
   });
 });

--- a/server/tests/review.service.test.ts
+++ b/server/tests/review.service.test.ts
@@ -113,7 +113,7 @@ describe('review.service', () => {
 
   describe('deleteReview', () => {
     it('deletes review inside a sequelize transaction when no related comments exist', async () => {
-      const transaction = { id: 'tx', commit: vi.fn(), rollback: vi.fn() };
+      const transaction = { commit: vi.fn(), rollback: vi.fn() };
       vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
         makeReviewModel({ id: 3, userId: 7 }) as never
       );
@@ -132,7 +132,7 @@ describe('review.service', () => {
     });
 
     it('throws 409 when related comments exist', async () => {
-      const transaction = { id: 'tx', commit: vi.fn(), rollback: vi.fn() };
+      const transaction = { commit: vi.fn(), rollback: vi.fn() };
       vi.mocked(reviewRepository.findReviewById).mockResolvedValue(
         makeReviewModel({ id: 3, userId: 7 }) as never
       );

--- a/server/tests/reviews-delete.test.ts
+++ b/server/tests/reviews-delete.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { Transaction } from 'sequelize';
 
 import reviewRouter from '../src/routes/reviews';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import Review from '../src/models/Review';
 import Comment from '../src/models/Comment';
 import { sequelize } from '../src/sequelize';
@@ -28,6 +29,7 @@ function makeApp(setUserId?: number, setUserRole?: string) {
     next();
   });
   app.use('/api', reviewRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
@@ -44,7 +46,7 @@ afterEach(() => {
 
 describe('DELETE /api/reviews/:reviewId', () => {
   // 無効なレビューID（整数以外）のテスト
-  it('returns 400 for invalid id (non-integer)', async () => {
+  it('reviewId が不正（非整数）のとき 400 を返す', async () => {
     const spyFind = vi.spyOn(Review, 'findByPk');
     const res = await request(app).delete('/api/reviews/1.5');
     expect(res.status).toBe(400);
@@ -54,7 +56,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // 未認証のリクエストのテスト
-  it('returns 401 when unauthenticated', async () => {
+  it('未認証時は 401 を返す', async () => {
     const unauthApp = makeApp(); // do not set userId
     const res = await request(unauthApp).delete('/api/reviews/1');
     expect(res.status).toBe(401);
@@ -62,7 +64,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // レビューが見つからない場合のテスト
-  it('returns 404 when review not found', async () => {
+  it('レビューが存在しないとき 404 を返す', async () => {
     vi.spyOn(Review, 'findByPk').mockResolvedValue(null);
     const res = await request(app).delete('/api/reviews/999');
     expect(res.status).toBe(404);
@@ -70,7 +72,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // 禁止されたアクセス（所有者でない）のテスト
-  it('returns 403 when not owner', async () => {
+  it('所有者でない場合は 403 を返す', async () => {
     type FakeReview = { get: (key: string) => number | null };
     const fakeReview: FakeReview = { get: (k: string) => (k === 'userId' ? 99 : null) };
     vi.spyOn(Review, 'findByPk').mockResolvedValue(fakeReview as unknown as ReviewInstance);
@@ -80,7 +82,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
     expect(res.body.error.code).toBe('FORBIDDEN');
   });
 
-  it('allows admin to delete non-owned review', async () => {
+  it('admin は非所有レビューでも削除できる', async () => {
     const adminApp = makeApp(2, 'admin');
     type FakeReviewWithDestroy = {
       get: (key: string) => number | null;
@@ -102,7 +104,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // 関連コメントが存在する場合の競合のテスト
-  it('returns 409 when related comments exist', async () => {
+  it('関連コメントが存在するとき 409 を返す', async () => {
     type FakeReview = { get: (key: string) => number | null };
     const fakeReview: FakeReview = { get: (k: string) => (k === 'userId' ? 2 : null) };
 
@@ -119,7 +121,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // 正常な削除のテスト
-  it('returns 204 and deletes review when ok', async () => {
+  it('正常系では 204 を返してレビューを削除する', async () => {
     type FakeReviewWithDestroy = {
       get: (key: string) => number | null;
       destroy: ReturnType<typeof vi.fn>;
@@ -141,7 +143,7 @@ describe('DELETE /api/reviews/:reviewId', () => {
   });
 
   // トランザクション失敗時の内部サーバーエラーのテスト
-  it('returns 500 when transaction creation fails', async () => {
+  it('トランザクション生成失敗時は 500 を返す', async () => {
     type FakeReview = { get: (key: string) => number | null };
     const fakeReview: FakeReview = { get: (k: string) => (k === 'userId' ? 2 : null) };
     vi.spyOn(Review, 'findByPk').mockResolvedValue(fakeReview as unknown as ReviewInstance);

--- a/server/tests/reviews-post.test.ts
+++ b/server/tests/reviews-post.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import reviewRouter from '../src/routes/reviews';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import Review from '../src/models/Review';
 import Book from '../src/models/Book';
 
@@ -22,6 +23,7 @@ function makeApp(setUserId?: number, setUserRole?: string) {
     next();
   });
   app.use('/api', reviewRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
@@ -37,7 +39,7 @@ afterEach(() => {
 });
 
 describe('POST /api/reviews', () => {
-  it('returns 401 when unauthenticated', async () => {
+  it('未認証時は 401 を返す', async () => {
     const unauthApp = makeApp();
     const res = await request(unauthApp)
       .post('/api/reviews')
@@ -46,7 +48,7 @@ describe('POST /api/reviews', () => {
     expect(res.body.error.code).toBe('AUTHENTICATION_REQUIRED');
   });
 
-  it('returns 400 when validation fails', async () => {
+  it('バリデーションエラー時は 400 を返す', async () => {
     // バリデーションエラー時は details に該当フィールドが含まれることを確認
     const res = await request(app)
       .post('/api/reviews')
@@ -59,7 +61,7 @@ describe('POST /api/reviews', () => {
     expect(fields).toContain('rating');
   });
 
-  it('returns 404 when book not found', async () => {
+  it('対象書籍が存在しないとき 404 を返す', async () => {
     vi.spyOn(Book, 'findByPk').mockResolvedValue(null);
     const res = await request(app)
       .post('/api/reviews')
@@ -68,7 +70,7 @@ describe('POST /api/reviews', () => {
     expect(res.body.error.code).toBe('BOOK_NOT_FOUND');
   });
 
-  it('returns 201 and created review when ok (rating optional)', async () => {
+  it('正常系では 201 と作成済みレビューを返す（rating 任意）', async () => {
     // 正常系：Book 存在確認 -> Review.create の流れをモック
     vi.spyOn(Book, 'findByPk').mockResolvedValue({ id: 1 } as unknown as BookInstance);
     vi.spyOn(Review, 'create').mockResolvedValue({
@@ -93,7 +95,7 @@ describe('POST /api/reviews', () => {
     expect(res.body.data.userId).toBe(2);
   });
 
-  it('returns 500 when create fails', async () => {
+  it('作成処理で例外が発生したとき 500 を返す', async () => {
     vi.spyOn(Book, 'findByPk').mockResolvedValue({ id: 1 } as unknown as BookInstance);
     vi.spyOn(Review, 'create').mockRejectedValue(new Error('DB fail'));
 

--- a/server/tests/reviews-update.test.ts
+++ b/server/tests/reviews-update.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 import reviewRouter from '../src/routes/reviews';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import Review from '../src/models/Review';
 
 // テスト目的：レビュー更新（PUT）のバリデーション、権限、更新処理を検証します
@@ -21,6 +22,7 @@ function makeApp(setUserId?: number, setUserRole?: string) {
     next();
   });
   app.use('/api', reviewRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
@@ -37,7 +39,7 @@ afterEach(() => {
 
 describe('PUT /api/reviews/:reviewId', () => {
   // 無効なレビューID（整数以外）のテスト
-  it('returns 400 for invalid id (non-integer)', async () => {
+  it('reviewId が不正（非整数）のとき 400 を返す', async () => {
     const spyFind = vi.spyOn(Review, 'findByPk');
     const res = await request(app).put('/api/reviews/1.5').send({ content: 'x' });
     expect(res.status).toBe(400);
@@ -47,7 +49,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // 未認証のリクエストのテスト
-  it('returns 401 when unauthenticated', async () => {
+  it('未認証時は 401 を返す', async () => {
     const unauthApp = makeApp(); // do not set userId
     const res = await request(unauthApp).put('/api/reviews/1').send({ content: 'ok' });
     expect(res.status).toBe(401);
@@ -55,7 +57,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // レビューが見つからない場合のテスト
-  it('returns 404 when review not found', async () => {
+  it('レビューが存在しないとき 404 を返す', async () => {
     vi.spyOn(Review, 'findByPk').mockResolvedValue(null);
     const res = await request(app).put('/api/reviews/999').send({ content: 'ok' });
     expect(res.status).toBe(404);
@@ -63,7 +65,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // 禁止されたアクセス（所有者でない）のテスト
-  it('returns 403 when not owner', async () => {
+  it('所有者でない場合は 403 を返す', async () => {
     type FakeReview = { get: (key: string) => number | null };
     const fakeReview: FakeReview = { get: (k: string) => (k === 'userId' ? 99 : null) };
     vi.spyOn(Review, 'findByPk').mockResolvedValue(fakeReview as unknown as ReviewInstance);
@@ -73,7 +75,7 @@ describe('PUT /api/reviews/:reviewId', () => {
     expect(res.body.error.code).toBe('FORBIDDEN');
   });
 
-  it('allows admin to update non-owned review', async () => {
+  it('admin は非所有レビューでも更新できる', async () => {
     const adminApp = makeApp(2, 'admin');
     const createdAt = new Date().toISOString();
     const updatedAt = new Date().toISOString();
@@ -110,7 +112,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // コンテンツのバリデーションエラーのテスト
-  it('returns 400 when content is missing or invalid', async () => {
+  it('content が不足または不正なとき 400 を返す', async () => {
     type FakeReview = { get: (key: string) => number | null };
     const fakeReview: FakeReview = { get: (k: string) => (k === 'userId' ? 2 : null) };
     vi.spyOn(Review, 'findByPk').mockResolvedValue(fakeReview as unknown as ReviewInstance);
@@ -129,7 +131,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // 正常な更新のテスト
-  it('returns 200 and updated review when ok', async () => {
+  it('正常系では 200 と更新済みレビューを返す', async () => {
     type FakeReviewWithUpdate = {
       get: (key: string) => number | null;
       update: ReturnType<typeof vi.fn>;
@@ -148,7 +150,7 @@ describe('PUT /api/reviews/:reviewId', () => {
   });
 
   // 更新失敗時の内部サーバーエラーのテスト
-  it('returns 500 when update fails', async () => {
+  it('更新処理で例外が発生したとき 500 を返す', async () => {
     type FakeReviewWithUpdate = {
       get: (key: string) => number | null;
       update: ReturnType<typeof vi.fn>;

--- a/server/tests/sequelize-errors.test.ts
+++ b/server/tests/sequelize-errors.test.ts
@@ -22,6 +22,15 @@ describe('sequelizeErrors', () => {
     expect(isUniqueConstraintError(error, ['username'])).toBe(true);
   });
 
+  it('sqlMessage フォールバックで重複を検出できる', () => {
+    const error = {
+      name: 'SequelizeUniqueConstraintError',
+      sqlMessage: "Duplicate entry 'alice' for key 'username'",
+    };
+
+    expect(isUniqueConstraintError(error, ['username'])).toBe(true);
+  });
+
   it('ターゲットなしの場合は一意制約違反として true を返す', () => {
     const error = {
       name: 'SequelizeUniqueConstraintError',

--- a/server/tests/sequelize-errors.test.ts
+++ b/server/tests/sequelize-errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUniqueConstraintError } from '../src/utils/sequelizeErrors';
+
+describe('sequelizeErrors', () => {
+  it('SequelizeUniqueConstraintError の path 一致を検出できる', () => {
+    const error = {
+      name: 'SequelizeUniqueConstraintError',
+      errors: [{ path: 'email' }],
+    };
+
+    expect(isUniqueConstraintError(error, ['email'])).toBe(true);
+    expect(isUniqueConstraintError(error, ['username'])).toBe(false);
+  });
+
+  it('fields キー一致を検出できる', () => {
+    const error = {
+      name: 'SequelizeUniqueConstraintError',
+      fields: { username: 'alice' },
+    };
+
+    expect(isUniqueConstraintError(error, ['username'])).toBe(true);
+  });
+
+  it('ターゲットなしの場合は一意制約違反として true を返す', () => {
+    const error = {
+      name: 'SequelizeUniqueConstraintError',
+      errors: [{ path: 'ISBN' }],
+    };
+
+    expect(isUniqueConstraintError(error)).toBe(true);
+  });
+});

--- a/server/tests/user.controller.test.ts
+++ b/server/tests/user.controller.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
@@ -26,6 +26,10 @@ function makeResponse(): MockResponse {
   return res;
 }
 
+function makeNext() {
+  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+}
+
 describe('user.controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,8 +38,9 @@ describe('user.controller', () => {
   it('returns 400 when id is invalid', async () => {
     const req = makeRequest('abc');
     const res = makeResponse();
+    const next = makeNext();
 
-    await getUserProfile(req, res);
+    await getUserProfile(req, res, next);
 
     expect(userService.getUserProfile).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
@@ -50,25 +55,20 @@ describe('user.controller', () => {
   it('returns 404 for USER_NOT_FOUND', async () => {
     const req = makeRequest('10');
     const res = makeResponse();
+    const next = makeNext();
     vi.mocked(userService.getUserProfile).mockRejectedValue(
       new ApiError(404, 'USER_NOT_FOUND', ERROR_MESSAGES.USER_NOT_FOUND)
     );
 
-    await getUserProfile(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      error: {
-        message: ERROR_MESSAGES.USER_NOT_FOUND,
-        code: 'USER_NOT_FOUND',
-      },
-    });
+    await getUserProfile(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
   });
 
   it('returns 200 with profile on success', async () => {
     const req = makeRequest('10');
     const res = makeResponse();
+    const next = makeNext();
     const data = {
       id: 10,
       username: 'bob',
@@ -78,7 +78,7 @@ describe('user.controller', () => {
     };
     vi.mocked(userService.getUserProfile).mockResolvedValue(data);
 
-    await getUserProfile(req, res);
+    await getUserProfile(req, res, next);
 
     expect(userService.getUserProfile).toHaveBeenCalledWith(10);
     expect(res.json).toHaveBeenCalledWith({ success: true, data });

--- a/server/tests/user.controller.test.ts
+++ b/server/tests/user.controller.test.ts
@@ -27,7 +27,7 @@ function makeResponse(): MockResponse {
 }
 
 function makeNext() {
-  return vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+  return vi.fn<NextFunction>();
 }
 
 describe('user.controller', () => {
@@ -62,7 +62,13 @@ describe('user.controller', () => {
 
     await getUserProfile(req, res, next);
     expect(next).toHaveBeenCalledOnce();
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    const [error] = next.mock.calls[0];
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      statusCode: 404,
+      code: 'USER_NOT_FOUND',
+      message: ERROR_MESSAGES.USER_NOT_FOUND,
+    });
   });
 
   it('returns 200 with profile on success', async () => {

--- a/server/tests/user.controller.test.ts
+++ b/server/tests/user.controller.test.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ERROR_MESSAGES } from '../src/constants/error-messages';
@@ -26,8 +27,10 @@ function makeResponse(): MockResponse {
   return res;
 }
 
-function makeNext() {
-  return vi.fn<NextFunction>();
+type MockNextFunction = NextFunction & Mock<NextFunction>;
+
+function makeNext(): MockNextFunction {
+  return vi.fn() as unknown as MockNextFunction;
 }
 
 describe('user.controller', () => {

--- a/server/tests/users.route.test.ts
+++ b/server/tests/users.route.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import usersRouter from '../src/routes/users';
+import { apiErrorHandler } from '../src/middleware/errorHandler';
 import User from '../src/models/Users';
 import Review from '../src/models/Review';
 import Favorite from '../src/models/Favorite';
@@ -11,10 +12,11 @@ import Favorite from '../src/models/Favorite';
 function makeApp() {
   const app = express();
   app.use('/api/users', usersRouter);
+  app.use(apiErrorHandler);
   return app;
 }
 
-describe('Users route', () => {
+describe('Users ルート', () => {
   let app: express.Express;
 
   beforeEach(() => {
@@ -24,7 +26,7 @@ describe('Users route', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns 400 when id is invalid (non positive integer)', async () => {
+  it('id が不正（非正整数）のとき 400 を返す', async () => {
     // 無効な ID （abc）でリクエスト
     const res = await request(app).get('/api/users/abc');
     // 400 Bad Request を確認
@@ -33,7 +35,7 @@ describe('Users route', () => {
     expect(res.body.error.code).toBe('INVALID_USER_ID');
   });
 
-  it('returns 404 when user does not exist', async () => {
+  it('ユーザーが存在しないとき 404 を返す', async () => {
     // User.findByPk が null を返すようにモック（ユーザーが存在しない）
     vi.spyOn(User, 'findByPk').mockResolvedValue(null);
     // ユーザー 123 を取得
@@ -44,7 +46,7 @@ describe('Users route', () => {
     expect(res.body.error.code).toBe('USER_NOT_FOUND');
   });
 
-  it('returns user profile when user exists', async () => {
+  it('ユーザーが存在する場合はプロフィールを返す', async () => {
     // モック用のユーザーオブジェクトを作成
     const fakeUser = { toJSON: () => ({ id: 1, username: 'u', createdAt: '2025-06-01' }) } as unknown as InstanceType<typeof User>;
     // User.findByPk がモックユーザーを返すようにモック
@@ -64,7 +66,7 @@ describe('Users route', () => {
     expect(res.body.data).toMatchObject({ id: 1, username: 'u', reviewCount: 5, favoriteCount: 3 });
   });
 
-  it('returns 500 if underlying service throws', async () => {
+  it('下位サービスが例外を投げたとき 500 を返す', async () => {
     // User.findByPk が正常なオブジェクトを返すようにモック
     vi.spyOn(User, 'findByPk').mockResolvedValue({ toJSON: () => ({ id: 2, username: 'foo' }) } as unknown as InstanceType<typeof User>);
     // Review.count がエラーをスロー（DB エラーを模擬）


### PR DESCRIPTION

## 📝 背景

`controller / service / repository / validator` の責務分離に伴い、抜本的なリファクタリングを実施。

## 🛠️ 変更内容

### 1. 例外処理共通化の基盤追加

- `server/src/utils/asyncHandler.ts` を新規追加
- 非同期 Controller の例外を `next` へ委譲し、`apiErrorHandler` で一元処理する方式を導入

### 2. Controller 実装の統一（重複 try/catch 撤去）

- `auth.controller.ts`
- `book.controller.ts`
- `comment.controller.ts`
- `review.controller.ts`
- `user.controller.ts`

実施内容:
- 重複 `try/catch` を削除
- 個別 `sendApiError` 呼び出しを削除
- 個別ロギング分岐を削除
- `ApiError` / 想定外例外は `next` 委譲へ統一

### 3. 振る舞い互換性（壊していない点）

- バリデーション失敗時の `400` は維持
- 未認証時の `401` は維持
- 正常系 `200 / 201 / 204` は維持
- エラー整形責務のみ Controller から middleware へ移動（API契約は維持）

### 4. テスト更新（実装方針追従）

- `server/tests/auth.controller.test.ts`
- `server/tests/comment.controller.test.ts`
- `server/tests/review.controller.test.ts`
- `server/tests/user.controller.test.ts`

変更点:
- `next` モックを導入
- 例外系は「直接レスポンス検証」から「`next` 委譲検証」へ更新
- 正常系 / バリデーション / 未認証の既存検証は維持

### 5. ドキュメント更新

- `docs/projects/book-review-app/specs/進捗管理/バック進捗.md`
- `docs/projects/book-review-app/specs/進捗管理/全体進捗.md`

## 👀 レビュー観点（レビュアー向け）

- Controller の責務が「入力検証 + サービス呼び出し + 正常レスポンス」に収束しているか
- 例外経路が `next` 経由で漏れなく middleware に委譲されているか
- テストが新方針（`next` 委譲）を適切に担保しているか

## ✅ テスト方法

```bash
cd server
npm run test:ci -- tests/auth.controller.test.ts tests/comment.controller.test.ts tests/review.controller.test.ts tests/user.controller.test.ts
npm run check-types
npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * APIエラーハンドリングロジックを集約・標準化しました
  * エラーレスポンス形式を統一しました

* **Tests**
  * エラーハンドリング周辺のテストを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->